### PR TITLE
Add custom Rollup plugins to build workflow

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -45,6 +45,7 @@ export interface BuildOptions {
   target?: boolean | string[];
   hashEntries?: boolean;
   mapBase?: string;
+  customPlugins?: [];
 }
 
 export async function build (input: string[] | Record<string,string>, opts: BuildOptions): Promise<ImportMap> {
@@ -116,6 +117,10 @@ export async function build (input: string[] | Record<string,string>, opts: Buil
       env: opts.env
     })]
   };
+
+  if (opts.customPlugins) {
+    rollupOptions.plugins = rollupOptions.plugins.concat(opts.customPlugins);
+  }
 
   if (opts.minify) {
     rollupOptions.plugins.push(terserPlugin.terser({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -590,7 +590,7 @@ ${bold('Command Flags')}
             'hash-entries',
             'out', // out can also be boolean
             'minify'
-          ], ['map-base', 'dir', 'out', 'format', /* TODO: build map support 'map' */, 'in'], ['external', 'banner']);
+          ], ['map-base', 'dir', 'out', 'format', /* TODO: build map support 'map' */, 'in', 'custom-plugins'], ['external', 'banner']);
           if (options.out && projectPaths.length > 1)
               throw new JspmUserError(`${bold('jspm build --out')} does not support execution in multiple projects.`);
           if (options.node)
@@ -680,6 +680,16 @@ ${bold('Command Flags')}
           }
           else if (options.out) {
             options.mapBase = path.dirname(path.resolve(options.out));
+          }
+
+          if (options.customPlugins) {
+            const pluginsFile = path.resolve(options.customPlugins);
+            if (!fs.existsSync(pluginsFile))
+              throw new JspmUserError(`Custom plugins file ${path.relative(process.cwd(), pluginsFile)} for build not found.`);
+            const customPlugins = require(pluginsFile);
+            if (typeof customPlugins !== "function")
+              hrow new JspmUserError(`Custom plugins file ${path.relative(process.cwd(), pluginsFile)} for build is invalid.`);
+            options.customPlugins = customPlugins(options, buildArgs);
           }
           let outMap = await api.build(buildArgs, options);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -688,7 +688,7 @@ ${bold('Command Flags')}
               throw new JspmUserError(`Custom plugins file ${path.relative(process.cwd(), pluginsFile)} for build not found.`);
             const customPlugins = require(pluginsFile);
             if (typeof customPlugins !== "function")
-              hrow new JspmUserError(`Custom plugins file ${path.relative(process.cwd(), pluginsFile)} for build is invalid.`);
+              throw new JspmUserError(`Custom plugins file ${path.relative(process.cwd(), pluginsFile)} for build is invalid.`);
             options.customPlugins = customPlugins(options, buildArgs);
           }
           let outMap = await api.build(buildArgs, options);


### PR DESCRIPTION
Hi @guybedford,
This is my propoal for issue #2499.

`$ jspm build ./src/app.js --dir ./dist --custom-plugins ./jspm.plugins.js`

with `jspm.plugins.js` as :
```js
const litSass = require('@ponday/rollup-plugin-lit-sass');

module.exports = (buildArgs, options) => {
    return [
        litSass({})
    ]
};
```
`buildArgs` and `options` parameters could be usefull to setup plugins.

Thanks for your great work 👍 
