### PR TITLE
Upgrade rollup-plugin-terser to fix vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vscode
 node_modules
 lib

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jspm",
   "description": "Universal ES Module Package Manager",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "main": "lib/api.js",
   "types": "lib/api.d.ts",
   "dependencies": {
@@ -30,7 +30,7 @@
     "rimraf": "^2.6.3",
     "rollup": "^1.11.3",
     "rollup-plugin-jspm": "^1.1.0",
-    "rollup-plugin-terser": "^4.0.4",
+    "rollup-plugin-terser": "^5.1.3",
     "semver": "^5.7.0",
     "spdx-license-list": "^6.0.0",
     "sver": "^1.8.2",

--- a/src/api.ts
+++ b/src/api.ts
@@ -27,7 +27,7 @@ export { build } from './build';
 if (process.env.globalJspm !== undefined) {
   process.once('unhandledRejection', err => {
     log('Internal Error: Unhandled promise rejection.', LogType.err);
-    logErr(err.stack || err);
+    logErr(err['stack'] || err);
     process.exit(1);
   });
   process.once('SIGINT', () => {

--- a/src/install/bin.ts
+++ b/src/install/bin.ts
@@ -68,6 +68,7 @@ const winBin = (binModulePath: string) => `@setlocal
 `;
 
 let _isCygwin;
+// @ts-ignore
 function isCygwin () {
   if (typeof _isCygwin === 'boolean')
     return _isCygwin;

--- a/src/install/fetch.ts
+++ b/src/install/fetch.ts
@@ -16,7 +16,7 @@
 
 import { Readable as ReadableStream } from 'stream';
 import nodeFetch from 'node-fetch';
-import HttpsProxyAgent from 'https-proxy-agent';
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import { Agent as NodeAgent, AgentOptions } from 'https';
 import { hasProperties, retry, bold } from '../utils/common';
 import { URL, parse as parseURL } from 'url';


### PR DESCRIPTION
The current rollup-plugin-terser depends on serialize-javascript with a
security vulnerability. This has been patched in version
rollup-plugin-terser v5.1.3

Resolve #2505

Also suppressed 3 typescript errors due to style.