### PR TITLE
Fix Object.assign({}, string)

### DIFF
--- a/src/install/fetch.ts
+++ b/src/install/fetch.ts
@@ -269,7 +269,7 @@ export default class FetchClass {
         if (credentials.proxy) {
           if (!existingAgents)
             proxyAgents.set(credentials.proxy, existingAgents = []);
-          existingAgents.push(agent = new HttpsProxyAgent(Object.assign({}, credentials.proxy)));
+          existingAgents.push(agent = new HttpsProxyAgent(Object.assign({}, agentOptions)));
         }
         else {
           agents.push(agent = <Agent>(new NodeAgent(agentOptions)));

--- a/src/install/fetch.ts
+++ b/src/install/fetch.ts
@@ -233,7 +233,7 @@ export default class FetchClass {
     if (credentials.proxy && url.startsWith('https:')) {
       if (typeof credentials.proxy === 'string') {
         const proxyURL = parseURL(credentials.proxy);
-        (<ProxyAgentOptions>agentOptions).host = proxyURL.host;
+        (<ProxyAgentOptions>agentOptions).host = proxyURL.hostname;
         (<ProxyAgentOptions>agentOptions).port = parseInt(proxyURL.port);
       }
       else {


### PR DESCRIPTION
cause env.https_proxy not work