### PR TITLE
Fix install scoped package with binaries

### DIFF
--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -709,7 +709,7 @@ export class Installer {
         this.binFolderChecked = true;
       }
       await Promise.all(Object.keys(config.bin).map(p => 
-        writeBinScripts(binDir, p, resolvedPkgName.replace(':', path.sep) + path.sep + config.bin[p])
+        writeBinScripts(binDir, p.replace(/(@.*\/)/, ""), resolvedPkgName.replace(':', path.sep) + path.sep + config.bin[p])
       ));
     }
   }


### PR DESCRIPTION
When I install a scoped package with binaries I'll get this error :
```bash
$ jspm install  @mapbox/geojson-rewind
err (jspm) Internal Error: Unhandled promise rejection.
Error: ENOENT: no such file or directory, open '[...]/jspm_packages/.bin/@mapbox/geojson-rewind'
```
jspm install command don't stripe scope in path so the destination folder doesn't exists.
My PR is to remove the scope with a regexp before writing file.