### PR TITLE
fix: don't pass input pins to update

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -43,7 +43,7 @@ export default async function update(packages: string[], flags: Flags) {
           packages.length ? packages.join(", ") : "everything"
         )}. (${env.join(", ")})`
       );
-    await generator.update(packages.length ? packages : inputPins);
+    await generator.update(packages.length ? packages : undefined);
     stopSpinner();
   }
 


### PR DESCRIPTION
Small fix, passing no arguments to `generator.update()` does a full update of all top-level packages. Passing in the pins sometimes throws because they can include subpaths.