### PR TITLE
fix: Use existing importmap for build by passing `--map` flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jspm/generator": "^1.1.10",
+        "@jspm/generator": "^1.1.12",
         "cac": "^6.7.14",
         "ora": "^6.3.0",
         "picocolors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "jspm.js"
   ],
   "dependencies": {
-    "@jspm/generator": "^1.1.10",
+    "@jspm/generator": "^1.1.12",
     "cac": "^6.7.14",
     "ora": "^6.3.0",
     "picocolors": "^1.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -293,6 +293,7 @@ Clears the global module fetch cache, for situations where the contents of a dep
 
 cli
   .command("build [entry]", "Build the module using importmap")
+  .option(...mapOpt)
   .option(...buildConfigOpt)
   .option(...buildOutputOpt)
   .action(wrapCommand(build));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,11 @@ export const availableProviders = [
   "jsdelivr",
   "skypack",
   "unpkg",
-  "esm.sh",
+  /*
+    Disabling esm.sh provider for now. There is a bug for installing lit.
+    https://github.com/jspm/generator/issues/335
+  */
+  // "esm.sh",
   "jspm.io#system",
 ];
 

--- a/test/ownname.test.ts
+++ b/test/ownname.test.ts
@@ -9,11 +9,11 @@ const scenarios: Scenario[] = [
     commands: ["jspm install app"],
     validationFn: async (files: Map<string, string>) => {
       // Installing the own-name package "app" should result in the version of
-      // es-module-lexer in the import map being upgraded to 1.3.1, since it's a
+      // es-module-lexer in the import map being upgraded to 1.4.1, since it's a
       // transitive dependency of "./app.js".
       const map = JSON.parse(files.get("importmap.json"));
       assert(
-        map?.imports?.["es-module-lexer"]?.includes("es-module-lexer@1.3.1")
+        map?.imports?.["es-module-lexer"]?.includes("es-module-lexer@1.4.1")
       );
     },
   },


### PR DESCRIPTION
Adds `--map` option for `jspm build` command.
While moving the `jspm-vscode` project to use `jspm-cli` workflow. We will generate the `importmap.json` only once. And use it for re-runs or update it only when needed.

So, when the extension is being built. We should use the existing map. Currently the `cli` throws an error because `--map` is not allowed for `build` command.

Usage reference -> https://github.com/jspm/jspm-vscode/blob/refactor-build-workflow/chompfile.toml#L9

Eg

```sh
jspm build --map importmap.json --config rollup-config.mjs
```