### PR TITLE
(chore): Release 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jspm",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jspm",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@jspm/generator": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jspm",
   "type": "module",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Import Map Package Manager",
   "license": "Apache-2.0",
   "bin": {


### PR DESCRIPTION
Keeping it up for review. Marking the version as `3.2.0` since we are dropping the `freeze` with install feature now.