### PR TITLE
fix: remove existing fields before writing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,6 +170,9 @@ async function writeJsonOutput(
   // (this way we can install into deno.json without destroying configurations)
   try {
     const existing = JSON.parse(await fs.readFile(mapFile, "utf8"));
+    delete existing.imports;
+    delete existing.scopes;
+    delete existing.integrity;
     map = Object.assign({}, existing, map);
   } catch {}
 


### PR DESCRIPTION
This removes existing import map fields before writing. This ensures that fields that become empty will be fully removed. For example, when building the import map without integrity after previously building it with integrity.
