### PR TITLE
feat: link with input HTML map when no importmap.json is present

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -37,7 +37,7 @@ In some cases there may be ambiguity. For instance, you may want to link the NPM
 If no modules are given, all "imports" in the initial map are relinked.
 
 ### Options
-* `-m, --map` _&lt;file&gt;_                File containing initial import map (default: importmap.json)
+* `-m, --map` _&lt;file&gt;_                File containing initial import map (defaults to importmap.json, or the input HTML if linking) 
 * `-o, --output` _&lt;file&gt;_             File to inject the final import map into (default: --map / importmap.json) 
 * `-e, --env` &lt;[environments](#environments)&gt;        Comma-separated environment condition overrides 
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;  Comma-separated dependency resolution overrides 
@@ -65,7 +65,7 @@ jspm link ./src/cli.js
 Link an HTML file and update its import map including preload and integrity tags
   
 ```
-jspm link --map index.html --integrity --preload dynamic
+jspm link --map index.html --integrity --preload
 ```
 ## install
 
@@ -79,7 +79,7 @@ Installs packages into an import map, along with all of the dependencies that ar
 If no packages are provided, all "imports" in the initial map are reinstalled.
 
 ### Options
-* `-m, --map` _&lt;file&gt;_                File containing initial import map (default: importmap.json)
+* `-m, --map` _&lt;file&gt;_                File containing initial import map (defaults to importmap.json, or the input HTML if linking) 
 * `-o, --output` _&lt;file&gt;_             File to inject the final import map into (default: --map / importmap.json) 
 * `-e, --env` &lt;[environments](#environments)&gt;        Comma-separated environment condition overrides 
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;  Comma-separated dependency resolution overrides 
@@ -129,7 +129,7 @@ jspm uninstall [flags] [...packages]
 Uninstalls packages from an import map. The given packages must be valid package specifiers, such as `npm:react@18.0.0`, `denoland:oak` or `lit`, and must be present in the initial import map.
 
 ### Options
-* `-m, --map` _&lt;file&gt;_                File containing initial import map (default: importmap.json)
+* `-m, --map` _&lt;file&gt;_                File containing initial import map (defaults to importmap.json, or the input HTML if linking) 
 * `-o, --output` _&lt;file&gt;_             File to inject the final import map into (default: --map / importmap.json) 
 * `-e, --env` &lt;[environments](#environments)&gt;        Comma-separated environment condition overrides 
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;  Comma-separated dependency resolution overrides 
@@ -161,7 +161,7 @@ jspm update [flags] [...packages]
 Updates packages in an import map to the latest versions that are compatible with the local `package.json`. The given packages must be valid package specifiers, such as `npm:react@18.0.0`, `denoland:oak` or `lit`, and must be present in the initial import map.
 
 ### Options
-* `-m, --map` _&lt;file&gt;_                File containing initial import map (default: importmap.json)
+* `-m, --map` _&lt;file&gt;_                File containing initial import map (defaults to importmap.json, or the input HTML if linking) 
 * `-o, --output` _&lt;file&gt;_             File to inject the final import map into (default: --map / importmap.json) 
 * `-e, --env` &lt;[environments](#environments)&gt;        Comma-separated environment condition overrides 
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;  Comma-separated dependency resolution overrides 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ export const cli = cac(c.yellow("jspm"));
 type opt = [string, string, any];
 const mapOpt: opt = [
   "-m, --map <file>",
-  "File containing initial import map",
+  "File containing initial import map (defaults to importmap.json, or the input HTML if linking)",
   {},
 ];
 const envOpt: opt = [
@@ -144,7 +144,7 @@ cli
     (
       name
     ) => `Link an HTML file and update its import map including preload and integrity tags
-  $ ${name} link --map index.html --integrity --preload dynamic
+  $ ${name} link --map index.html --integrity --preload
 `
   )
   .usage(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ type opt = [string, string, any];
 const mapOpt: opt = [
   "-m, --map <file>",
   "File containing initial import map",
-  { default: "importmap.json" },
+  {},
 ];
 const envOpt: opt = [
   "-e, --env <environments>",

--- a/src/link.ts
+++ b/src/link.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import { extname } from "node:path";
 import { pathToFileURL } from "url";
 import c from "picocolors";
 import { type Generator } from "@jspm/generator";
@@ -15,7 +16,6 @@ import {
   writeOutput,
 } from "./utils";
 import { withType } from "./logger";
-import { extname } from "node:path";
 
 export default async function link(modules: string[], flags: Flags) {
   const log = withType("link/link");

--- a/src/link.ts
+++ b/src/link.ts
@@ -9,11 +9,13 @@ import {
   getInput,
   getInputPath,
   getOutputPath,
+  isJsExtension,
   startSpinner,
   stopSpinner,
   writeOutput,
 } from "./utils";
 import { withType } from "./logger";
+import { extname } from "node:path";
 
 export default async function link(modules: string[], flags: Flags) {
   const log = withType("link/link");
@@ -21,8 +23,10 @@ export default async function link(modules: string[], flags: Flags) {
   log(`Linking modules: ${modules.join(", ")}`);
   log(`Flags: ${JSON.stringify(flags)}`);
 
+  const fallbackMap = !modules[0] || isJsExtension(extname(modules[0])) ? undefined : modules[0];
+
   const env = await getEnv(flags);
-  const inputMapPath = getInputPath(flags);
+  const inputMapPath = getInputPath(flags, fallbackMap);
   const outputMapPath = getOutputPath(flags);
   const generator = await getGenerator(flags);
 
@@ -36,7 +40,7 @@ export default async function link(modules: string[], flags: Flags) {
   // The input map is either from a JSON file or extracted from an HTML file.
   // In the latter case we want to trace any inline modules from the HTML file
   // as well, since they may have imports that are not in the import map yet:
-  const input = await getInput(flags);
+  const input = await getInput(flags, fallbackMap);
   const pins = inlinePins.concat(resolvedModules.map((p) => p.target));
   let allPins = pins;
   if (input) {

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -15,3 +15,4 @@
   }
 }
 </script>
+<script type="module" src="app.js"></script>

--- a/test/link.test.ts
+++ b/test/link.test.ts
@@ -139,6 +139,18 @@ const scenarios: Scenario[] = [
       assert(!map.imports?.["react-dom"]);
     },
   },
+
+  // Support the HTML as being the import map when there is no importmap.json:
+  {
+    files: new Map([...htmlFile, ['app.js', 'import "react"']]),
+    commands: ["jspm link index.html -o index.html --integrity"],
+    validationFn: async (files: Map<string, string>) => {
+      const source = files.get('index.html');
+      assert(source.includes('"integrity"'));
+      assert(source.includes('"./app.js": "sha384-f+bWmpnsmFol2CAkqy/ALGgZsi/mIaBIIhbvFLVuQzt0LNz96zLSDcz1fnF2K22q"'));
+      assert(source.includes('"https://ga.jspm.io/npm:react@18.2.0/dev.index.js": "sha384-eSJrEMXot96AKVLYz8C1nY3CpLMuBMHIAiYhs7vfM09SQo+5X+1w6t3Ldpnw+VWU"'))
+    },
+  },
 ];
 
 await runScenarios(scenarios);


### PR DESCRIPTION
This updates `jspm link file.html` to use the import map from the HTML file when no `importmap.json` is present, resolving the workflow issue described in https://github.com/jspm/jspm-cli/issues/2575.