### PR TITLE
feat: build file names, better guidance

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -538,8 +538,19 @@ Uses RollupJS under the hood to create optimized bundles.
 
 The package entry points as defined in the package.json "exports" field are built, with the
 entire package copied into the output directory. As such, it is a whole-package transformation.
+
+Build externals are taken from the package.json "dependencies" to form a roughly configurationless
+build workflow (dependencies in "devDependencies" or otherwise are inlined into the build).
+
 Includes and ignores can be specified using the package.json "files" and "ignore" fields,
 optionally using the JSPM overrides for these via the "jspm" property in the package.json.
+
+Any build import map shoud be generated separately via a subsequent install operation on the
+build folder, for example like:
+
+${c.bold('jspm install -d dist -C production --flatten-scopes --combine-subpaths')}
+
+to generate an optimized production map.
 `
   )
   .action(wrapCommand(build));

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -453,12 +453,14 @@ export function getInputPath(flags: GenerateFlags, fallbackDefaultMap = defaultM
   }
 
   // If importmap.json exists, use it
-  if (exists(defaultMapPath)) {
-    return resolve(defaultMapPath);
+  const defaultMapPathResolved = resolve(flags.dir ?? '.', defaultMapPath);
+  if (exists(defaultMapPathResolved)) {
+    return defaultMapPathResolved;
   }
 
   // Otherwise use the provided fallback
-  return resolve(fallbackDefaultMap);
+  const fallbackDefaultMapResolved = resolve(flags.dir ?? '.', fallbackDefaultMap);
+  return fallbackDefaultMapResolved;
 }
 
 export function getOutputPath(flags: GenerateOutputFlags): string {
@@ -468,12 +470,14 @@ export function getOutputPath(flags: GenerateOutputFlags): string {
   }
 
   // If importmap.json exists, use that
-  if (exists(defaultMapPath)) {
-    return resolve(defaultMapPath);
+  const defaultMapPathResolved = resolve(flags.dir ?? '.', defaultMapPath);
+  if (defaultMapPathResolved) {
+    return defaultMapPathResolved;
   }
 
   // Default to importmap.json if nothing else is available
-  return resolve(defaultMapPath);
+  const fallbackDefaultMapResolved = resolve(flags.dir ?? '.', defaultMapPath);
+  return fallbackDefaultMapResolved;
 }
 
 function getOutputMapUrl(flags: GenerateOutputFlags): URL {

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -18,6 +18,7 @@ import {
 import { Installer } from '../install/installer.js';
 import { SemverRange } from 'sver';
 import { getIntegrity } from '../common/integrity.js';
+import { isNode } from '../common/env.js';
 
 let realpath, pathToFileURL;
 
@@ -241,7 +242,7 @@ export class Resolver {
   }
 
   async realPath(url: string): Promise<string> {
-    if (!url.startsWith('file:') || this.preserveSymlinks) return url;
+    if (!isNode || !url.startsWith('file:') || this.preserveSymlinks) return url;
     let encodedColon = false;
     url = url.replace(/%3a/i, () => {
       encodedColon = true;


### PR DESCRIPTION
This fixes the build file names when using `jspm build` so that chunks are located into `lib/chunk-hash.js` and to avoid copying build files which are otherwise built into chunks already.

This also adds instructions for `jspm build` for how to generate a production map to guide users who want to execute the package instead of publishing it.