### PR TITLE
fix: stable version publishing, rebase fix

### DIFF
--- a/cli/test/publish.test.ts
+++ b/cli/test/publish.test.ts
@@ -221,7 +221,6 @@ test('publish and eject', async () => {
     ],
     validationFn: async updatedFiles => {
       // Verify ejected files
-      console.log(updatedFiles);
       assert(updatedFiles.has(`${ejectDir}/index.js`), 'Should have ejected index.js');
       assert(updatedFiles.has(`${ejectDir}/src/utils.js`), 'Should have ejected src/utils.js');
 
@@ -238,6 +237,209 @@ test('publish and eject', async () => {
       } catch (e) {
         assert.fail(`Failed to parse import map: ${e.message}`);
       }
+    }
+  });
+});
+
+// Test complex package with importmap.js
+test('publish complex package with importmap', async () => {
+  const files = new Map();
+
+  // Create package.json
+  files.set(
+    'package.json',
+    JSON.stringify(
+      {
+        name: 'jspm-test123',
+        version: 'web',
+        description: '',
+        type: 'module',
+        exports: {
+          './sandbox': './lib/sandbox.js'
+        },
+        dependencies: {
+          '@jspm/generator': '^2.6.1',
+          codemirror: '5.59.4',
+          'es-module-lexer': '^1.7.0'
+        }
+      },
+      null,
+      2
+    )
+  );
+
+  // Create lib/sandbox.js
+  files.set(
+    'lib/sandbox.js',
+    `import { LitElement, html } from 'lit-element';
+import { Buffer } from '@jspm/core/nodelibs/buffer';
+import zlib from '@jspm/core/nodelibs/zlib';
+import CodeMirror from 'codemirror';
+import 'codemirror/mode/css/css.js';
+import 'codemirror/mode/javascript/javascript.js';
+import 'codemirror/mode/xml/xml.js';
+import 'codemirror/mode/htmlmixed/htmlmixed.js';
+import { lookup } from '@jspm/generator';`
+  );
+
+  // Create importmap.js
+  const importMapContent = `(map => {
+  const mapUrl = document.currentScript.src;
+  const resolve = imports => Object.fromEntries(Object.entries(imports ).map(([k, v]) => [k, new URL(v, mapUrl).href]));
+  document.head.appendChild(Object.assign(document.createElement("script"), {
+    type: "importmap",
+    innerHTML: JSON.stringify({
+      imports: resolve(map.imports),
+      scopes: Object.fromEntries(Object.entries(map.scopes).map(([k, v]) => [new URL(k, mapUrl).href, resolve(v)]))
+    })
+  }));
+})
+({
+  "imports": {
+    "jspm-test123/sandbox": "./lib/sandbox.js"
+  },
+  "scopes": {
+    "./": {
+      "@jspm/core/nodelibs/buffer": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/buffer.js",
+      "@jspm/core/nodelibs/util": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/util.js",
+      "@jspm/core/nodelibs/zlib": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/zlib.js",
+      "@jspm/generator": "https://ga.jspm.io/npm:@jspm/generator@2.6.2/dist/generator.js",
+      "codemirror": "https://ga.jspm.io/npm:codemirror@5.59.4/lib/codemirror.js",
+      "codemirror/mode/": "https://ga.jspm.io/npm:codemirror@5.59.4/mode/",
+      "lit-element": "https://ga.jspm.io/npm:lit-element@4.2.0/development/index.js"
+    },
+    "https://ga.jspm.io/": {
+      "#fetch": "https://ga.jspm.io/npm:@jspm/generator@2.6.2/dist/fetch-native.js",
+      "#lib/config/files/index.js": "https://ga.jspm.io/npm:@babel/core@7.26.10/lib/config/files/index-browser.js",
+      "#lib/config/resolve-targets.js": "https://ga.jspm.io/npm:@babel/core@7.26.10/lib/config/resolve-targets-browser.js",
+      "#lib/internal/streams/stream.js": "https://ga.jspm.io/npm:readable-stream@2.3.8/lib/internal/streams/stream-browser.js",
+      "#lib/pass-through-decoder.js": "https://ga.jspm.io/npm:text-decoder@1.2.2/lib/browser-decoder.js",
+      "#lib/transform-file.js": "https://ga.jspm.io/npm:@babel/core@7.26.10/lib/transform-file-browser.js",
+      "#lib/utf8-decoder.js": "https://ga.jspm.io/npm:text-decoder@1.2.2/lib/browser-decoder.js",
+      "#node.js": "https://ga.jspm.io/npm:browserslist@4.25.0/browser.js",
+      "@ampproject/remapping": "https://ga.jspm.io/npm:@ampproject/remapping@2.3.0/dist/remapping.umd.js",
+      "@babel/code-frame": "https://ga.jspm.io/npm:@babel/code-frame@7.27.1/lib/index.js",
+      "@babel/compat-data/native-modules": "https://ga.jspm.io/npm:@babel/compat-data@7.28.0/native-modules.js",
+      "@babel/compat-data/plugins": "https://ga.jspm.io/npm:@babel/compat-data@7.28.0/plugins.js",
+      "@babel/core": "https://ga.jspm.io/npm:@babel/core@7.26.10/lib/dev.index.js",
+      "@babel/generator": "https://ga.jspm.io/npm:@babel/generator@7.28.0/lib/index.js",
+      "@babel/helper-annotate-as-pure": "https://ga.jspm.io/npm:@babel/helper-annotate-as-pure@7.27.3/lib/index.js",
+      "@babel/helper-compilation-targets": "https://ga.jspm.io/npm:@babel/helper-compilation-targets@7.27.2/lib/index.js",
+      "@babel/helper-create-class-features-plugin": "https://ga.jspm.io/npm:@babel/helper-create-class-features-plugin@7.27.1/lib/index.js",
+      "@babel/helper-globals/data/builtin-lower.json": "https://ga.jspm.io/npm:@babel/helper-globals@7.28.0/data/builtin-lower.json.js",
+      "@babel/helper-globals/data/builtin-upper.json": "https://ga.jspm.io/npm:@babel/helper-globals@7.28.0/data/builtin-upper.json.js",
+      "@babel/helper-member-expression-to-functions": "https://ga.jspm.io/npm:@babel/helper-member-expression-to-functions@7.27.1/lib/index.js",
+      "@babel/helper-module-imports": "https://ga.jspm.io/npm:@babel/helper-module-imports@7.27.1/lib/index.js",
+      "@babel/helper-module-transforms": "https://ga.jspm.io/npm:@babel/helper-module-transforms@7.27.3/lib/index.js",
+      "@babel/helper-optimise-call-expression": "https://ga.jspm.io/npm:@babel/helper-optimise-call-expression@7.27.1/lib/index.js",
+      "@babel/helper-plugin-utils": "https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.27.1/lib/index.js",
+      "@babel/helper-replace-supers": "https://ga.jspm.io/npm:@babel/helper-replace-supers@7.27.1/lib/index.js",
+      "@babel/helper-skip-transparent-expression-wrappers": "https://ga.jspm.io/npm:@babel/helper-skip-transparent-expression-wrappers@7.27.1/lib/index.js",
+      "@babel/helper-string-parser": "https://ga.jspm.io/npm:@babel/helper-string-parser@7.27.1/lib/index.js",
+      "@babel/helper-validator-identifier": "https://ga.jspm.io/npm:@babel/helper-validator-identifier@7.27.1/lib/index.js",
+      "@babel/helper-validator-option": "https://ga.jspm.io/npm:@babel/helper-validator-option@7.27.1/lib/index.js",
+      "@babel/helpers": "https://ga.jspm.io/npm:@babel/helpers@7.28.2/lib/index.js",
+      "@babel/parser": "https://ga.jspm.io/npm:@babel/parser@7.28.0/lib/index.js",
+      "@babel/plugin-syntax-import-attributes": "https://ga.jspm.io/npm:@babel/plugin-syntax-import-attributes@7.27.1/lib/index.js",
+      "@babel/plugin-syntax-jsx": "https://ga.jspm.io/npm:@babel/plugin-syntax-jsx@7.27.1/lib/index.js",
+      "@babel/plugin-syntax-typescript": "https://ga.jspm.io/npm:@babel/plugin-syntax-typescript@7.27.1/lib/index.js",
+      "@babel/plugin-transform-modules-commonjs": "https://ga.jspm.io/npm:@babel/plugin-transform-modules-commonjs@7.27.1/lib/index.js",
+      "@babel/plugin-transform-typescript": "https://ga.jspm.io/npm:@babel/plugin-transform-typescript@7.28.0/lib/index.js",
+      "@babel/preset-typescript": "https://ga.jspm.io/npm:@babel/preset-typescript@7.27.1/lib/index.js",
+      "@babel/template": "https://ga.jspm.io/npm:@babel/template@7.27.2/lib/index.js",
+      "@babel/traverse": "https://ga.jspm.io/npm:@babel/traverse@7.28.0/lib/index.js",
+      "@babel/types": "https://ga.jspm.io/npm:@babel/types@7.28.2/lib/index.js",
+      "@jridgewell/gen-mapping": "https://ga.jspm.io/npm:@jridgewell/gen-mapping@0.3.12/dist/gen-mapping.umd.js",
+      "@jridgewell/resolve-uri": "https://ga.jspm.io/npm:@jridgewell/resolve-uri@3.1.2/dist/resolve-uri.umd.js",
+      "@jridgewell/sourcemap-codec": "https://ga.jspm.io/npm:@jridgewell/sourcemap-codec@1.5.4/dist/sourcemap-codec.umd.js",
+      "@jridgewell/trace-mapping": "https://ga.jspm.io/npm:@jridgewell/trace-mapping@0.3.29/dist/trace-mapping.umd.js",
+      "@jspm/import-map": "https://ga.jspm.io/npm:@jspm/import-map@1.2.0/dist/map.js",
+      "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.0/development/reactive-element.js",
+      "assert": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/assert.js",
+      "b4a": "https://ga.jspm.io/npm:b4a@1.6.7/browser.js",
+      "balanced-match": "https://ga.jspm.io/npm:balanced-match@3.0.1/index.js",
+      "brace-expansion": "https://ga.jspm.io/npm:brace-expansion@4.0.1/index.js",
+      "browserslist": "https://ga.jspm.io/npm:browserslist@4.25.0/index.js",
+      "buffer": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/buffer.js",
+      "caniuse-lite/dist/unpacker/agents": "https://ga.jspm.io/npm:caniuse-lite@1.0.30001727/dist/unpacker/agents.js",
+      "convert-source-map": "https://ga.jspm.io/npm:convert-source-map@2.0.0/index.js",
+      "core-util-is": "https://ga.jspm.io/npm:core-util-is@1.0.3/lib/util.js",
+      "debug": "https://ga.jspm.io/npm:debug@4.4.1/src/browser.js",
+      "electron-to-chromium/versions": "https://ga.jspm.io/npm:electron-to-chromium@1.5.191/versions.js",
+      "es-module-lexer": "https://ga.jspm.io/npm:es-module-lexer@1.7.0/dist/lexer.js",
+      "es-module-lexer/js": "https://ga.jspm.io/npm:es-module-lexer@1.7.0/dist/lexer.asm.js",
+      "events": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/events.js",
+      "fast-fifo": "https://ga.jspm.io/npm:fast-fifo@1.3.2/index.js",
+      "fs": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/fs.js",
+      "gensync": "https://ga.jspm.io/npm:gensync@1.0.0-beta.2/index.js",
+      "immediate": "https://ga.jspm.io/npm:immediate@3.0.6/lib/browser.js",
+      "inherits": "https://ga.jspm.io/npm:inherits@2.0.4/inherits_browser.js",
+      "isarray": "https://ga.jspm.io/npm:isarray@1.0.0/index.js",
+      "js-tokens": "https://ga.jspm.io/npm:js-tokens@4.0.0/index.js",
+      "jsesc": "https://ga.jspm.io/npm:jsesc@3.1.0/jsesc.js",
+      "lie": "https://ga.jspm.io/npm:lie@3.3.0/lib/browser.js",
+      "lit-html": "https://ga.jspm.io/npm:lit-html@3.3.0/development/lit-html.js",
+      "lru-cache": "https://ga.jspm.io/npm:lru-cache@5.1.1/index.js",
+      "minimatch": "https://ga.jspm.io/npm:minimatch@10.0.2/dist/esm/index.js",
+      "ms": "https://ga.jspm.io/npm:ms@2.1.3/index.js",
+      "node-releases/data/processed/envs.json": "https://ga.jspm.io/npm:node-releases@2.0.19/data/processed/envs.json.js",
+      "node-releases/data/release-schedule/release-schedule.json": "https://ga.jspm.io/npm:node-releases@2.0.19/data/release-schedule/release-schedule.json.js",
+      "pako": "https://ga.jspm.io/npm:pako@2.1.0/dist/pako.esm.mjs",
+      "path": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/path.js",
+      "picocolors": "https://ga.jspm.io/npm:picocolors@1.1.1/picocolors.browser.js",
+      "process": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/process.js",
+      "process-nextick-args": "https://ga.jspm.io/npm:process-nextick-args@2.0.1/index.js",
+      "readable-stream": "https://ga.jspm.io/npm:readable-stream@2.3.8/readable-browser.js",
+      "safe-buffer": "https://ga.jspm.io/npm:safe-buffer@5.1.2/index.js",
+      "semver": "https://ga.jspm.io/npm:semver@6.3.1/semver.js",
+      "setimmediate": "https://ga.jspm.io/npm:setimmediate@1.0.5/setImmediate.js",
+      "streamx": "https://ga.jspm.io/npm:streamx@2.22.1/index.js",
+      "string_decoder": "https://ga.jspm.io/npm:string_decoder@1.1.1/lib/string_decoder.js",
+      "sver": "https://ga.jspm.io/npm:sver@1.8.4/sver.js",
+      "sver/convert-range.js": "https://ga.jspm.io/npm:sver@1.8.4/convert-range.js",
+      "tar-stream": "https://ga.jspm.io/npm:tar-stream@3.1.7/index.js",
+      "text-decoder": "https://ga.jspm.io/npm:text-decoder@1.2.2/index.js",
+      "url": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/url.js",
+      "util": "https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/util.js",
+      "util-deprecate": "https://ga.jspm.io/npm:util-deprecate@1.0.2/browser.js",
+      "yallist": "https://ga.jspm.io/npm:yallist@3.1.1/yallist.js"
+    }
+  }
+});`;
+
+  files.set('importmap.js', importMapContent);
+
+  // Publish the package
+  await run({
+    files,
+    commands: ['jspm publish -p jspm.io --no-usage'],
+    validationFn: async _updatedFiles => {
+      // After publish, fetch the importmap.js from the published URL
+      const packageUrl = 'https://jspm.io/app:jspm-test123@web';
+      const importmapUrl = `${packageUrl}/importmap.json`;
+
+      let publishMap;
+      try {
+        const response = await fetch(importmapUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch importmap: ${response.status}`);
+        }
+        publishMap = await response.json();
+      } catch (error) {
+        console.error('Error fetching importmap:', error);
+        throw error;
+      }
+
+      assert.deepStrictEqual(publishMap.scopes['https://jspm.io/'], {
+        '@jspm/core/nodelibs/buffer':
+          'https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/buffer.js',
+        '@jspm/core/nodelibs/zlib':
+          'https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/zlib.js',
+        '@jspm/generator': 'https://ga.jspm.io/npm:@jspm/generator@2.6.2/dist/generator.js',
+        codemirror: 'https://ga.jspm.io/npm:codemirror@5.59.4/lib/codemirror.js',
+        'codemirror/mode/': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/',
+        'lit-element': 'https://ga.jspm.io/npm:lit-element@4.2.0/index.js'
+      });
     }
   });
 });

--- a/cli/test/scenarios.ts
+++ b/cli/test/scenarios.ts
@@ -73,7 +73,8 @@ export async function run(scenario: Scenario) {
     }
 
     if (!scenario.validationFn) {
-      if (scenario.expectError) throw new Error(`Scenario "${scenario.commands}" expected test to fail`);
+      if (scenario.expectError)
+        throw new Error(`Scenario "${scenario.commands}" expected test to fail`);
       throw new Error(`Scenario "${scenario.commands}" has no validation function for test`);
     }
     await scenario.validationFn(await mapDirectory(dir));

--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -760,7 +760,7 @@ export class Generator {
    *
    * By using link, we guarantee that the import map constructed is only for what is truly
    * needed and loaded. Dynamic imports that are statically analyzable are traced by link.
-   * 
+   *
    * If a custom resolver is configured, it will be applied to the provided specifiers
    * and all their dependencies during the linking process.
    */
@@ -1032,7 +1032,7 @@ export class Generator {
    * // Install all exports of the package, based on enumerating all the package export subpaths.
    * await generator.install({ alias: 'mypkg', target: './packages/local-pkg', subpaths: true });
    * ```
-   * 
+   *
    * Will respect {@link GeneratorOptions.customResolver} for dependency specifier resolution. If requiring
    * a {@link GeneratorOptions.customResolver} to apply at the top-level, use {@link Generator.link} instead.
    */
@@ -1466,7 +1466,7 @@ export class Generator {
     );
 
     if (install) {
-      await this.install({ alias: name, target: pkg, subpaths: true });
+      await this.install({ alias: name, target: pkg, subpaths: true }, 'freeze');
       // we then substitute the package URL with the final publish URL
       this.importMap.rebase('about:blank');
       this.importMap.replace(pkg, packageUrl);

--- a/import-map/test/cases/rebase-scope-unification.js
+++ b/import-map/test/cases/rebase-scope-unification.js
@@ -1,0 +1,80 @@
+import { deepStrictEqual } from 'assert';
+import { ImportMap } from '@jspm/import-map';
+
+// Test case for scope unification during rebase
+// When multiple scopes rebase to the same URL, they should be unified
+const map = new ImportMap({
+  mapUrl: 'file:///C:/Users/Guy/AppData/Local/Temp/jspm-yaQepn/',
+  rootUrl: null,
+  map: {
+    imports: {
+      'jspm-test123/sandbox': 'file:///C:/Users/Guy/AppData/Local/Temp/jspm-yaQepn/lib/sandbox.js'
+    },
+    scopes: {
+      './': {
+        'codemirror/mode/': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/'
+      },
+      'https://ga.jspm.io/': {
+        '#fetch': 'https://ga.jspm.io/npm:@jspm/generator@2.6.2/dist/fetch-native.js',
+        '#lib/config/files/index.js': 'https://ga.jspm.io/npm:@babel/core@7.26.10/lib/config/files/index-browser.js',
+        '#lib/config/resolve-targets.js': 'https://ga.jspm.io/npm:@babel/core@7.26.10/lib/config/resolve-targets-browser.js',
+        '#lib/internal/streams/stream.js': 'https://ga.jspm.io/npm:readable-stream@2.3.8/lib/internal/streams/stream-browser.js',
+        '#lib/pass-through-decoder.js': 'https://ga.jspm.io/npm:text-decoder@1.2.2/lib/browser-decoder.js',
+        '#lib/transform-file.js': 'https://ga.jspm.io/npm:@babel/core@7.26.10/lib/transform-file-browser.js',
+        '#lib/utf8-decoder.js': 'https://ga.jspm.io/npm:text-decoder@1.2.2/lib/browser-decoder.js',
+        '#node.js': 'https://ga.jspm.io/npm:browserslist@4.25.0/browser.js'
+      },
+      'file:///C:/Users/Guy/AppData/Local/Temp/jspm-yaQepn/': {
+        'codemirror/mode/css/css.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/css/css.js',
+        'codemirror/mode/htmlmixed/htmlmixed.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/htmlmixed/htmlmixed.js',
+        'codemirror/mode/javascript/javascript.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/javascript/javascript.js',
+        'codemirror/mode/xml/xml.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/xml/xml.js',
+        '@jspm/core/nodelibs/buffer': 'https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/buffer.js',
+        '@jspm/core/nodelibs/zlib': 'https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/zlib.js',
+        '@jspm/generator': 'https://ga.jspm.io/npm:@jspm/generator@2.6.3/dist/generator.js',
+        'codemirror': 'https://ga.jspm.io/npm:codemirror@5.59.4/lib/codemirror.js',
+        'lit-element': 'https://ga.jspm.io/npm:lit-element@4.2.1/index.js'
+      }
+    }
+  }
+});
+
+// Rebase to about:blank - this should unify the './' and 'file:///C:/Users/Guy/AppData/Local/Temp/jspm-yaQepn/' scopes
+// since they both resolve to the same URL
+map.rebase('about:blank');
+
+const result = map.toJSON();
+
+// The scopes for 'file:///C:/Users/Guy/AppData/Local/Temp/jspm-yaQepn/' should be unified
+// Both './' and the full file URL should resolve to the same scope after rebasing
+const expectedScopeUrl = 'file:///C:/Users/Guy/AppData/Local/Temp/jspm-yaQepn/';
+
+// Check that we have the unified scope
+if (!result.scopes[expectedScopeUrl]) {
+  throw new Error(`Expected scope for ${expectedScopeUrl} not found`);
+}
+
+const unifiedScope = result.scopes[expectedScopeUrl];
+
+// The unified scope should contain entries from both original scopes
+const expectedEntries = {
+  // From './' scope
+  'codemirror/mode/': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/',
+  // From 'file:///C:/Users/Guy/AppData/Local/Temp/jspm-yaQepn/' scope
+  'codemirror/mode/css/css.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/css/css.js',
+  'codemirror/mode/htmlmixed/htmlmixed.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/htmlmixed/htmlmixed.js',
+  'codemirror/mode/javascript/javascript.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/javascript/javascript.js',
+  'codemirror/mode/xml/xml.js': 'https://ga.jspm.io/npm:codemirror@5.59.4/mode/xml/xml.js',
+  '@jspm/core/nodelibs/buffer': 'https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/buffer.js',
+  '@jspm/core/nodelibs/zlib': 'https://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/zlib.js',
+  '@jspm/generator': 'https://ga.jspm.io/npm:@jspm/generator@2.6.3/dist/generator.js',
+  'codemirror': 'https://ga.jspm.io/npm:codemirror@5.59.4/lib/codemirror.js',
+  'lit-element': 'https://ga.jspm.io/npm:lit-element@4.2.1/index.js'
+};
+
+// Verify all expected entries are present
+for (const [key, value] of Object.entries(expectedEntries)) {
+  if (unifiedScope[key] !== value) {
+    throw new Error(`Expected unified scope to contain ${key}: ${value}, but got ${unifiedScope[key]}`);
+  }
+}


### PR DESCRIPTION
This fixes two publishing bugs:

1. During publishing, rebasing when two URLs rebase into the same scope URL, import mappings were being removed instead of merged in this case. This fixes that bug in import-map for all rebase operations.
2. Adding `install(target, 'freeze')` to the publish install that happens prior to publishing to ensure that version lock is fully maintained, and we don't update versions of dependencies during publishing (we only update conditional resolutions from development to production)

Tests added for both cases.