### PR TITLE
Parallel package fetching, packageConfigs option

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,8 +11,11 @@ jobs:
     name: Node.js Tests
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
-        node: [22.x, 23.x]
+        include:
+          - os: ubuntu-latest
+            node: 22.x
+          - os: windows-latest
+            node: 24.x
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -59,12 +59,11 @@ jobs:
           SKIP_PERF: 1
 
   test-servers:
-    name: Node.js & Deno Tests
+    name: Node.js Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18.x, 20.x, 21.x]
-        deno: ['2']
+        node: [20.x, 24.x]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -73,9 +72,6 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node }}
-    - uses: denoland/setup-deno@v1
-      with:
-        deno-version: ${{ matrix.deno }}
     - name: Setup Chomp
       uses: guybedford/chomp-action@v1
       env:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -63,7 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20.x, 24.x]
+        node: [18.x, 24.x]
+        deno: ['2']
     steps:
     - uses: actions/checkout@v2
       with:
@@ -72,6 +73,9 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node }}
+    - uses: denoland/setup-deno@v1
+      with:
+        deno-version: ${{ matrix.deno }}
     - name: Setup Chomp
       uses: guybedford/chomp-action@v1
       env:

--- a/cli/docs.md
+++ b/cli/docs.md
@@ -80,7 +80,7 @@ By default, output is limited to 20 items. Use --limit to see more items.
 **Options**
 * `-f, --filter` _&lt;pattern&gt;_        Filter exports by pattern (case-insensitive substring match) 
 * `-l, --limit` _&lt;number&gt;_          Limit the number of exports displayed (default: 20) 
-* `-p, --provider` &lt;[providers](#providers)&gt;     Provider to use for package resolution. Available providers: jspm.io, nodemodules, deno, jsdelivr, skypack, unpkg, esm.sh, jspm.io#system 
+* `-p, --provider` &lt;[providers](#providers)&gt;     Provider to use for package resolution. Available providers: jspm.io, nodemodules, deno, jsdelivr, unpkg, esm.sh, jspm.io#system 
 * `-q, --quiet`                   Quiet output (default: false)
 * `-d, --dir` _&lt;directory&gt;_         Package directory to operate on (defaults to working directory) 
 * `--disable-warning` _&lt;warnings&gt;_  Disable specific warnings (comma-separated list, e.g. file-count) 
@@ -151,7 +151,7 @@ Enhanced Security and Performance:
 * `-m, --map` _&lt;file&gt;_                 File containing initial import map (defaults to importmap.json, supports .js with a JSON import map embedded, or HTML with an inline import map) 
 * `-C, --conditions` _&lt;environments&gt;_  Comma-separated environment condition overrides (default: )
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;   Comma-separated dependency resolution overrides 
-* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, skypack, unpkg, esm.sh, jspm.io#system 
+* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, unpkg, esm.sh, jspm.io#system 
 * `--cache` _&lt;mode&gt;_                   Cache mode for fetches (online, offline, no-cache) (default: online)
 * `--release`                        Enable release mode (--flatten-scopes, --combine-subpaths, --C=production) (default: false)
 * `--integrity`                      Add module integrity attributes to the import map 
@@ -214,7 +214,7 @@ the same options as the 'jspm install' command with no arguments.
 * `-m, --map` _&lt;file&gt;_                 File containing initial import map (defaults to importmap.json, supports .js with a JSON import map embedded, or HTML with an inline import map) 
 * `-C, --conditions` _&lt;environments&gt;_  Comma-separated environment condition overrides (default: )
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;   Comma-separated dependency resolution overrides 
-* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, skypack, unpkg, esm.sh, jspm.io#system 
+* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, unpkg, esm.sh, jspm.io#system 
 * `--cache` _&lt;mode&gt;_                   Cache mode for fetches (online, offline, no-cache) (default: online)
 * `--release`                        Enable release mode (--flatten-scopes, --combine-subpaths, --C=production) (default: false)
 * `--integrity`                      Add module integrity attributes to the import map 
@@ -301,7 +301,7 @@ to generate an optimized production map.
 * `-m, --map` _&lt;file&gt;_                 File containing initial import map (defaults to importmap.json, supports .js with a JSON import map embedded, or HTML with an inline import map) 
 * `-C, --conditions` _&lt;environments&gt;_  Comma-separated environment condition overrides (default: )
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;   Comma-separated dependency resolution overrides 
-* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, skypack, unpkg, esm.sh, jspm.io#system 
+* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, unpkg, esm.sh, jspm.io#system 
 * `--cache` _&lt;mode&gt;_                   Cache mode for fetches (online, offline, no-cache) (default: online)
 * `--release`                        Enable release mode (--flatten-scopes, --combine-subpaths, --C=production) (default: false)
 * `-q, --quiet`                      Quiet output (default: false)
@@ -373,7 +373,7 @@ For ejecting a published package:
 * `-m, --map` _&lt;file&gt;_                 File containing initial import map (defaults to importmap.json, supports .js with a JSON import map embedded, or HTML with an inline import map) 
 * `-C, --conditions` _&lt;environments&gt;_  Comma-separated environment condition overrides (default: )
 * `-r, --resolution` &lt;[resolutions](#resolutions)&gt;   Comma-separated dependency resolution overrides 
-* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, skypack, unpkg, esm.sh, jspm.io#system 
+* `-p, --provider` &lt;[providers](#providers)&gt;        Default module provider. Available providers: jspm.io, nodemodules, deno, jsdelivr, unpkg, esm.sh, jspm.io#system 
 * `--cache` _&lt;mode&gt;_                   Cache mode for fetches (online, offline, no-cache) (default: online)
 * `--release`                        Enable release mode (--flatten-scopes, --combine-subpaths, --C=production) (default: true)
 * `--integrity`                      Add module integrity attributes to the import map 

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -127,7 +127,6 @@ export const availableProviders = [
   'nodemodules',
   'deno',
   'jsdelivr',
-  'skypack',
   'unpkg',
   'esm.sh',
   'jspm.io#system'

--- a/cli/test/integrity.test.ts
+++ b/cli/test/integrity.test.ts
@@ -61,13 +61,13 @@ test('Scenario using nodemodules provider should add integrity attribute', async
 //   });
 // });
 
-test('Installing package from skypack with integrity attribute', async () => {
+test('Installing package from unpkg with integrity attribute', async () => {
   await run({
     files: new Map(),
-    commands: ['jspm link lit --provider skypack --integrity -o importmap.json'],
+    commands: ['jspm link lit --provider unpkg --integrity -o importmap.json'],
     validationFn: async files => {
       const map = JSON.parse(files.get('importmap.json')!);
-      assert(map.imports.lit.includes('cdn.skypack.dev'));
+      assert(map.imports.lit.includes('unpkg.com'));
       assert(map.integrity);
     }
   });

--- a/generator/src/providers/deno.ts
+++ b/generator/src/providers/deno.ts
@@ -40,7 +40,7 @@ export function resolveBuiltin(specifier: string, env: string[]): string | Insta
   }
 }
 
-export async function pkgToUrl(pkg: ExactPackage): Promise<`${string}/`> {
+export function pkgToUrl(pkg: ExactPackage): `${string}/` {
   if (pkg.registry === 'deno') return `${stdlibUrl}@${pkg.version}/`;
   if (pkg.registry === 'denoland')
     return `${cdnUrl}${pkg.name}@${vCache[pkg.name] ? 'v' : ''}${pkg.version}/`;

--- a/generator/src/providers/esmsh.ts
+++ b/generator/src/providers/esmsh.ts
@@ -10,7 +10,7 @@ import type { ProviderContext } from './index.js';
 
 const cdnUrl = 'https://esm.sh/';
 
-export async function pkgToUrl(pkg: ExactPackage): Promise<`${string}/`> {
+export function pkgToUrl(pkg: ExactPackage): `${string}/` {
   // The wildcard '*' at the end tells the esm.sh CDN to externalise all
   // dependencies instead of bundling them into the returned module file.
   //   see https://esm.sh/#docs

--- a/generator/src/providers/index.ts
+++ b/generator/src/providers/index.ts
@@ -26,7 +26,11 @@ export interface Provider {
     url: string
   ): ExactPackage | { pkg: ExactPackage; subpath: `./${string}` | null; layer: string } | null;
 
-  pkgToUrl(this: ProviderContext, pkg: ExactPackage, layer?: string): Promise<`${string}/`>;
+  pkgToUrl(
+    this: ProviderContext,
+    pkg: ExactPackage,
+    layer?: string
+  ): `${string}/` | Promise<`${string}/`>;
 
   resolveLatestTarget(
     this: ProviderContext,
@@ -44,7 +48,7 @@ export interface Provider {
 
   getFileList?(this: ProviderContext, pkgUrl: string): Promise<Set<string> | undefined>;
 
-  download?(this: ProviderContext, pkg: ExactPackage): Promise<Record<string, ArrayBuffer>>;
+  download?(this: ProviderContext, pkg: ExactPackage): Promise<Record<string, Uint8Array>>;
 
   /**
    * Publish a package to the provider
@@ -204,11 +208,11 @@ export class ProviderManager {
    * @param url URL to parse
    * @returns Package information or null if URL can't be parsed
    */
-  async parseUrlPkg(url: string): Promise<{
+  parseUrlPkg(url: string): {
     pkg: ExactPackage;
     source: { provider: string; layer: string };
     subpath: `./${string}` | null;
-  } | null> {
+  } | null {
     for (const provider of Object.keys(this.providers).reverse()) {
       const providerInstance = this.providers[provider];
       const context = this.#getProviderContext(provider);
@@ -234,7 +238,11 @@ export class ProviderManager {
    * @param layer Layer to use
    * @returns URL for the package
    */
-  async pkgToUrl(pkg: ExactPackage, provider: string, layer = 'default'): Promise<`${string}/`> {
+  pkgToUrl(
+    pkg: ExactPackage,
+    provider: string,
+    layer = 'default'
+  ): `${string}/` | Promise<`${string}/`> {
     return this.#getProvider(provider).pkgToUrl.call(
       this.#getProviderContext(provider),
       pkg,

--- a/generator/src/providers/jsdelivr.ts
+++ b/generator/src/providers/jsdelivr.ts
@@ -8,7 +8,7 @@ import { SemverRange } from 'sver';
 
 const cdnUrl = 'https://cdn.jsdelivr.net/';
 
-export async function pkgToUrl(pkg: ExactPackage): Promise<`${string}/`> {
+export function pkgToUrl(pkg: ExactPackage): `${string}/` {
   return `${cdnUrl}${pkg.registry}/${pkg.name}@${pkg.version}/`;
 }
 

--- a/generator/src/providers/node.ts
+++ b/generator/src/providers/node.ts
@@ -74,7 +74,7 @@ export const nodeBuiltinSet = new Set<string>([
   'zlib'
 ]);
 
-export async function pkgToUrl(pkg: ExactPackage, layer: string): Promise<`${string}/`> {
+export function pkgToUrl(pkg: ExactPackage, layer: string): `${string}/` {
   if (pkg.registry !== 'node') return pkgToUrlJspm(pkg, layer);
   return `node:${pkg.name}/`;
 }

--- a/generator/src/providers/skypack.ts
+++ b/generator/src/providers/skypack.ts
@@ -8,7 +8,7 @@ import { SemverRange } from 'sver';
 
 const cdnUrl = 'https://cdn.skypack.dev/';
 
-export async function pkgToUrl(pkg: ExactPackage): Promise<`${string}/`> {
+export function pkgToUrl(pkg: ExactPackage): `${string}/` {
   return `${cdnUrl}${pkg.name}@${pkg.version}/`;
 }
 

--- a/generator/src/providers/unpkg.ts
+++ b/generator/src/providers/unpkg.ts
@@ -7,7 +7,7 @@ import { SemverRange } from 'sver';
 
 const cdnUrl = 'https://unpkg.com/';
 
-export async function pkgToUrl(pkg: ExactPackage): Promise<`${string}/`> {
+export function pkgToUrl(pkg: ExactPackage): `${string}/` {
   return `${cdnUrl}${pkg.name}@${pkg.version}/`;
 }
 

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -66,7 +66,7 @@ export interface TraceEntry {
 }
 
 export class Resolver {
-  pcfgPromises: Record<string, Promise<void>> = Object.create(null);
+  pcfgPromises: Record<string, Promise<PackageConfig | null>> = Object.create(null);
   analysisPromises: Record<string, Promise<void>> = Object.create(null);
   pcfgs: Record<string, PackageConfig | null> = Object.create(null);
   fetchOpts: any;
@@ -86,6 +86,7 @@ export class Resolver {
     env,
     fetchOpts,
     providerManager,
+    packageConfigs = {},
     preserveSymlinks = false,
     traceCjs = true,
     traceTs = true,
@@ -94,6 +95,7 @@ export class Resolver {
     env: string[];
     fetchOpts?: any;
     preserveSymlinks?: boolean;
+    packageConfigs?: Record<`${string}/`, PackageConfig>;
     traceCjs?: boolean;
     traceTs?: boolean;
     traceSystem: boolean;
@@ -109,6 +111,7 @@ export class Resolver {
     this.traceTs = traceTs;
     this.traceSystem = traceSystem;
     this.pm = providerManager;
+    Object.assign(this.pcfgs, packageConfigs);
   }
 
   resolveBuiltin(specifier: string): string | Install | undefined {
@@ -116,7 +119,7 @@ export class Resolver {
   }
 
   async getPackageBase(url: string): Promise<`${string}/`> {
-    const pkg = await this.pm.parseUrlPkg(url);
+    const pkg = this.pm.parseUrlPkg(url);
     if (pkg) return this.pm.pkgToUrl(pkg.pkg, pkg.source.provider, pkg.source.layer);
 
     let testUrl: URL;
@@ -127,9 +130,8 @@ export class Resolver {
     }
     const rootUrl = new URL('/', testUrl).href as `${string}/`;
     do {
-      let responseUrl;
-      if ((responseUrl = await this.checkPjson(testUrl.href)))
-        return new URL('.', responseUrl).href as `${string}/`;
+      let testUrlHref: `${string}/` = testUrl.href as `${string}/`;
+      if (await this.checkPjson(testUrlHref)) return testUrlHref;
       // No package base -> use directory itself
       if (testUrl.href === rootUrl) return new URL('./', url).href as `${string}/`;
     } while ((testUrl = new URL('../', testUrl)));
@@ -143,20 +145,19 @@ export class Resolver {
   // packages, and in resolution contexts we should skip straight to npm-style
   // backtracking to find package bases.
 
-  async getPackageConfig(pkgUrl: string): Promise<PackageConfig | null> {
+  getPackageConfig(pkgUrl: string): PackageConfig | null | Promise<PackageConfig | null> {
     const protocol = pkgUrl.slice(0, pkgUrl.indexOf(':') + 1);
     if (!isFetchProtocol(protocol)) return null;
     if (!pkgUrl.endsWith('/'))
       throw new Error(`Internal Error: Package URL must end in "/". Got ${pkgUrl}`);
     let cached = this.pcfgs[pkgUrl];
-    if (cached) return cached;
+    if (cached !== undefined) return cached;
     if (!this.pcfgPromises[pkgUrl])
       this.pcfgPromises[pkgUrl] = (async () => {
         const pcfg = await this.pm.getPackageConfig(pkgUrl);
         if (typeof pcfg === 'object') {
           if (pcfg !== null) {
-            this.pcfgs[pkgUrl] = pcfg;
-            return;
+            return (this.pcfgs[pkgUrl] = pcfg);
           }
         }
 
@@ -165,8 +166,7 @@ export class Resolver {
         } catch (e) {
           // CSP errors can't be detected, but should be treated as missing
           // therefore we just ignore errors as none
-          this.pcfgs[pkgUrl] = null;
-          return;
+          return (this.pcfgs[pkgUrl] = null);
         }
         switch (res.status) {
           case 200:
@@ -179,25 +179,23 @@ export class Resolver {
           case 404:
           case 406:
           case 500:
-            this.pcfgs[pkgUrl] = null;
-            return;
+            return (this.pcfgs[pkgUrl] = null);
           default:
             throw new JspmError(
               `Invalid status code ${res.status} reading package config for ${pkgUrl}. ${res.statusText}`
             );
         }
         if (res.headers && !res.headers.get('Content-Type')?.match(/^application\/json(;|$)/)) {
-          this.pcfgs[pkgUrl] = null;
+          return (this.pcfgs[pkgUrl] = null);
         } else {
           try {
-            this.pcfgs[pkgUrl] = await res.json();
+            return (this.pcfgs[pkgUrl] = await res.json());
           } catch (e) {
-            this.pcfgs[pkgUrl] = null;
+            return (this.pcfgs[pkgUrl] = null);
           }
         }
       })();
-    await this.pcfgPromises[pkgUrl];
-    return this.pcfgs[pkgUrl];
+    return this.pcfgPromises[pkgUrl];
   }
 
   async getDepList(pkgUrl: string, dev = false): Promise<string[]> {
@@ -216,9 +214,15 @@ export class Resolver {
     ];
   }
 
-  async checkPjson(url: string): Promise<string | false> {
-    if ((await this.getPackageConfig(url)) === null) return false;
-    return url;
+  checkPjson(url: string): boolean | Promise<boolean> {
+    const pcfg = this.getPackageConfig(url);
+    if (pcfg instanceof Promise) {
+      return pcfg.then(pcfg => {
+        if (pcfg === null) return false;
+        return true;
+      });
+    }
+    return true;
   }
 
   async exists(resolvedUrl: string) {

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -151,7 +151,9 @@ export class Resolver {
     if (!pkgUrl.endsWith('/'))
       throw new Error(`Internal Error: Package URL must end in "/". Got ${pkgUrl}`);
     let cached = this.pcfgs[pkgUrl];
-    if (cached !== undefined) return cached;
+    // TODO: fix timing bug that requires this return to be a promise
+    if (cached === null) return Promise.resolve(null);
+    if (cached) return cached;
     if (!this.pcfgPromises[pkgUrl])
       this.pcfgPromises[pkgUrl] = (async () => {
         const pcfg = await this.pm.getPackageConfig(pkgUrl);

--- a/generator/test/api/local.test.js
+++ b/generator/test/api/local.test.js
@@ -4,7 +4,10 @@ import assert from 'assert';
 const generator = new Generator({
   mapUrl: import.meta.url,
   defaultProvider: 'jspm.io',
-  env: ['production', 'browser']
+  env: ['production', 'browser'],
+  packageConfigs: {
+    '/generator/test': null
+  }
 });
 
 await generator.install({ target: './local/pkg', subpath: './custom' });


### PR DESCRIPTION
This adds a major performance optimization to package fetching - ensuring that during lockfile reconstruction all package configurations are fetched in parallel instead of serially which was causing a drastic slowdown for generation times on large import maps.

This also implements a new configuration option for the generator - `packageConfigs` which allows providing package configurations through an option, overriding any package.json fetching so that no package.json fetch happens at all for this and also allowing configurations to be overridden.

A useful side-effect of this new `packageConfigs` option is being able to define `null` for package paths that don't have package.json package configurations, so that the generator doesn't need to trigger 404 not found requests at all in these cases.

For example, if building packages from a URL like `https://mycompany.com/packages/...` you can set:

```js
new Generator({
  packageConfigs: {
    'https://mycompany.com/': null,
    'https://mycompany.com/packages/': null
  }
});
```

To ensure there is never a 404 request to `https://mycompany.com/package.json` or `https://mycompany.com/packages/package.json`.

The preferable approach is usually to define a provider of course, as that can hook the package lookup process anyway, but defining a provider is not always ideal as well.