### PR TITLE
fix: strict condition resolution for exports subpath enumeration

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1032,6 +1032,26 @@ return false;
 }
 
 /**
+ * Resolve an exports target to the single resolution it takes for the given env,
+ * matching the strict Node conditional resolution of Resolver.resolvePackageTarget.
+ *
+ * Unknown conditions are only speculatively expanded as a whole-target fallback,
+ * when no strict resolution exists at all, so that packages exporting solely
+ * under conditions we don't know about still resolve to something. Speculating
+ * inline would let an unknown condition ordered ahead of "default" shadow it,
+ * enumerating subpaths that then fail to resolve.
+ */
+function resolveTargetResolution(
+  exports: any,
+  files: Set<string> | undefined,
+  env: string[],
+  targetList: Set<string>
+) {
+  if (!expandTargetResolutions(exports, files, env, targetList, [], true, false))
+    expandTargetResolutions(exports, files, env, targetList, [], true, true);
+}
+
+/**
  * Expand a package exports field into its set of subpaths and resolution
  * With an optional file list for expanding globs
  */
@@ -1043,18 +1063,18 @@ export function expandExportsResolutions(
 ) {
   if (typeof exports !== 'object' || exports === null || !allDotKeys(exports)) {
     const targetList = new Set<string>();
-    expandTargetResolutions(exports, files, env, targetList, [], true);
+    resolveTargetResolution(exports, files, env, targetList);
     for (const target of targetList) {
       if (target.startsWith('./')) {
         const targetFile = target.slice(2);
-        if (!files || files.has(targetFile)) 
+        if (!files || files.has(targetFile))
 exportsResolutions.set('.', targetFile);
       }
     }
   } else {
     for (const subpath of Object.keys(exports)) {
       const targetList = new Set<string>();
-      expandTargetResolutions(exports[subpath], files, env, targetList, [], true);
+      resolveTargetResolution(exports[subpath], files, env, targetList);
       for (const target of targetList) {
         expandExportsTarget(
           exports as Record<string, any>,
@@ -1123,15 +1143,16 @@ function expandTargetResolutions(
   env: string[],
   targetList: Set<string>,
   envExclusions = env.map(condition => conditionMutualExclusions[condition]).filter(c => c),
-  firstOnly: boolean
+  firstOnly: boolean,
+  speculate = true
 ): boolean {
   if (typeof exports === 'string') {
-    if (exports.startsWith('./')) 
+    if (exports.startsWith('./'))
 targetList.add(exports);
     return true;
   } else if (Array.isArray(exports)) {
     for (const item of exports) {
-      if (expandTargetResolutions(item, files, env, targetList, envExclusions, firstOnly))
+      if (expandTargetResolutions(item, files, env, targetList, envExclusions, firstOnly, speculate))
         return true;
     }
     return false;
@@ -1151,13 +1172,14 @@ continue;
             env,
             targetList,
             envExclusions,
-            firstOnly
+            firstOnly,
+            speculate
           )
         ) {
           return true;
         }
       }
-      if (envExclusions.includes(condition)) 
+      if (!speculate || envExclusions.includes(condition))
 continue;
       const maybeNewExclusion = conditionMutualExclusions[condition];
       const newExclusions =
@@ -1172,10 +1194,11 @@ continue;
           env,
           targetList,
           newExclusions,
-          firstOnly
+          firstOnly,
+          speculate
         )
       ) {
-        if (firstOnly) 
+        if (firstOnly)
 return true;
         hasSomeResolution = true;
         envExclusions = newExclusions;

--- a/generator/src/common/package.test.ts
+++ b/generator/src/common/package.test.ts
@@ -1,4 +1,4 @@
-import { expandExportsEntries } from './package.js';
+import { expandExportsEntries, expandExportsResolutions, getWildcardPrefixes } from './package.js';
 import assert from 'node:assert';
 
 // Helper to convert Set to sorted array for assertion
@@ -432,6 +432,84 @@ const setToArray = set => Array.from(set).sort();
     'lib/utils/common.js',
     'lib/utils/index.js'
   ]);
+}
+
+// expandExportsResolutions must agree exactly with Resolver.resolvePackageTarget,
+// which is strict Node conditional resolution. Unknown conditions may only be
+// speculatively expanded when no env or "default" branch resolves at all.
+const browserEnv = ['browser', 'development', 'module', 'import', 'default'];
+
+// Test: unknown condition ordered before "default" must not shadow it
+{
+  const resolutions = new Map<string, string>();
+  expandExportsResolutions(
+    { '.': { worker: './w.js', default: './d.js' } },
+    browserEnv,
+    new Set(['w.js', 'd.js']),
+    resolutions
+  );
+  assert.deepEqual([...resolutions], [['.', 'd.js']]);
+}
+
+// Test: unknown condition ordered before an env condition must not shadow it
+{
+  const resolutions = new Map<string, string>();
+  expandExportsResolutions(
+    { '.': { worker: './w.js', browser: './b.js' } },
+    browserEnv,
+    new Set(['w.js', 'b.js']),
+    resolutions
+  );
+  assert.deepEqual([...resolutions], [['.', 'b.js']]);
+}
+
+// Test: unknown condition still resolves when nothing else matches
+{
+  const resolutions = new Map<string, string>();
+  expandExportsResolutions(
+    { '.': { worker: './w.js' } },
+    browserEnv,
+    new Set(['w.js']),
+    resolutions
+  );
+  assert.deepEqual([...resolutions], [['.', 'w.js']]);
+}
+
+// Test: "types" wildcard must not shadow "default" — jspm/jspm#2717
+{
+  const resolutions = new Map<string, string>();
+  expandExportsResolutions(
+    {
+      './src/*': { import: { types: './types/src/*', default: './src/*' } },
+      './dist/*': './dist/*'
+    },
+    browserEnv,
+    new Set([
+      'src/util.js',
+      'src/index.js',
+      'types/src/util.d.ts',
+      'types/src/index.d.ts',
+      'dist/color.js'
+    ]),
+    resolutions
+  );
+  assert.deepEqual(setToArray(resolutions.keys()), [
+    './dist/color.js',
+    './src/index.js',
+    './src/util.js'
+  ]);
+  assert.strictEqual(resolutions.get('./src/util.js'), 'src/util.js');
+}
+
+// Test: wildcard prefixes are derived from the resolved target, not a
+// speculative one — the suffix safety check must scan the real directory
+{
+  const prefixes = getWildcardPrefixes(
+    { './src/*.js': { import: { types: './types/*.d.ts', default: './src/*.js' } } },
+    browserEnv,
+    new Set(['src/util.js', 'src/index.js', 'types/util.d.ts'])
+  );
+  assert.deepEqual([...prefixes], ['./src/']);
 }
 
 console.log('All tests passed! ✨');

--- a/generator/src/common/package.ts
+++ b/generator/src/common/package.ts
@@ -66,7 +66,12 @@ export function getWildcardPrefixes(
   for (const subpath of Object.keys(exports)) {
     if (subpath.indexOf('*') === -1) continue;
     let targetList = new Set<string>();
-    expandTargetResolutions((exports as Record<string, ExportsTarget>)[subpath], files, env, targetList, [], true);
+    resolveTargetResolution(
+      (exports as Record<string, ExportsTarget>)[subpath],
+      files,
+      env,
+      targetList
+    );
     for (const target of targetList) {
       if (!target.startsWith('./') || target.indexOf('*') === -1) continue;
       const targetSuffix = target.slice(target.indexOf('*') + 1);
@@ -94,6 +99,26 @@ export function getWildcardPrefixes(
 }
 
 /**
+ * Resolve an exports target to the single resolution it takes for the given env,
+ * matching the strict Node conditional resolution of Resolver.resolvePackageTarget.
+ *
+ * Unknown conditions are only speculatively expanded as a whole-target fallback,
+ * when no strict resolution exists at all, so that packages exporting solely
+ * under conditions we don't know about still resolve to something. Speculating
+ * inline would let an unknown condition ordered ahead of "default" shadow it,
+ * enumerating subpaths that then fail to resolve.
+ */
+function resolveTargetResolution(
+  exports: ExportsTarget,
+  files: Set<string> | undefined,
+  env: string[],
+  targetList: Set<string>
+) {
+  if (!expandTargetResolutions(exports, files, env, targetList, [], true, false))
+    expandTargetResolutions(exports, files, env, targetList, [], true, true);
+}
+
+/**
  * Expand a package exports field into its set of subpaths and resolution
  * With an optional file list for expanding globs
  */
@@ -105,7 +130,7 @@ export function expandExportsResolutions(
 ) {
   if (typeof exports !== 'object' || exports === null || !allDotKeys(exports)) {
     let targetList = new Set<string>();
-    expandTargetResolutions(exports, files, env, targetList, [], true);
+    resolveTargetResolution(exports, files, env, targetList);
     for (const target of targetList) {
       if (target.startsWith('./')) {
         const targetFile = target.slice(2);
@@ -115,7 +140,12 @@ export function expandExportsResolutions(
   } else {
     for (const subpath of Object.keys(exports)) {
       let targetList = new Set<string>();
-      expandTargetResolutions((exports as Record<string, ExportsTarget>)[subpath], files, env, targetList, [], true);
+      resolveTargetResolution(
+        (exports as Record<string, ExportsTarget>)[subpath],
+        files,
+        env,
+        targetList
+      );
       for (const target of targetList) {
         expandExportsTarget(
           exports as Record<string, ExportsTarget>,
@@ -151,7 +181,14 @@ export function expandExportsEntries(
   } else {
     for (const subpath of Object.keys(exports)) {
       let targetList = new Set<string>();
-      expandTargetResolutions((exports as Record<string, ExportsTarget>)[subpath], files, env, targetList, [], false);
+      expandTargetResolutions(
+        (exports as Record<string, ExportsTarget>)[subpath],
+        files,
+        env,
+        targetList,
+        [],
+        false
+      );
       for (const target of targetList) {
         let map = new Map();
         expandExportsTarget(exports as Record<string, ExportsTarget>, subpath, target, files, map);
@@ -182,15 +219,20 @@ function expandTargetResolutions(
   files: Set<string> | undefined,
   env: string[],
   targetList: Set<string>,
-  envExclusions = env.map(condition => (conditionMutualExclusions as Record<string, string>)[condition]).filter(c => c),
-  firstOnly: boolean
+  envExclusions = env
+    .map(condition => (conditionMutualExclusions as Record<string, string>)[condition])
+    .filter(c => c),
+  firstOnly: boolean,
+  speculate = true
 ): boolean {
   if (typeof exports === 'string') {
     if (exports.startsWith('./')) targetList.add(exports);
     return true;
   } else if (Array.isArray(exports)) {
     for (const item of exports) {
-      if (expandTargetResolutions(item, files, env, targetList, envExclusions, firstOnly))
+      if (
+        expandTargetResolutions(item, files, env, targetList, envExclusions, firstOnly, speculate)
+      )
         return true;
     }
     return false;
@@ -209,13 +251,14 @@ function expandTargetResolutions(
             env,
             targetList,
             envExclusions,
-            firstOnly
+            firstOnly,
+            speculate
           )
         ) {
           return true;
         }
       }
-      if (envExclusions.includes(condition)) continue;
+      if (!speculate || envExclusions.includes(condition)) continue;
       const maybeNewExclusion = (conditionMutualExclusions as Record<string, string>)[condition];
       const newExclusions =
         maybeNewExclusion && !envExclusions.includes(maybeNewExclusion)
@@ -229,7 +272,8 @@ function expandTargetResolutions(
           env,
           targetList,
           newExclusions,
-          firstOnly
+          firstOnly,
+          speculate
         )
       ) {
         if (firstOnly) return true;
@@ -264,7 +308,8 @@ function expandExportsTarget(
   // and any subsequent *s become backreferences, enforcing that all wildcards
   // match the same value (per Node.js exports semantics).
   // See https://nodejs.org/api/packages.html#subpath-patterns
-  const regexPattern = target.slice(2)
+  const regexPattern = target
+    .slice(2)
     .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
     .replace('*', '(.+)')
     .replaceAll('*', '\\1');

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -1011,6 +1011,25 @@ async function getAnalysis(resolver: Resolver, resolvedUrl: string): Promise<Ana
 
     sourceText = new TextDecoder().decode(source);
 
+    // Declaration files are validly exported and remain mapped, but carry no
+    // runtime module graph - their specifiers follow TypeScript declaration
+    // resolution (a "./x.js" specifier naming an ./x.d.ts), so tracing them as
+    // imports resolves against files that need not exist.
+    if (
+      resolvedUrl.endsWith('.d.ts') ||
+      resolvedUrl.endsWith('.d.mts') ||
+      resolvedUrl.endsWith('.d.cts')
+    ) {
+      return {
+        deps: [],
+        dynamicDeps: [],
+        cjsLazyDeps: null,
+        size: sourceText.length,
+        format: 'typescript',
+        integrity: await getIntegrity(sourceText)
+      };
+    }
+
     if (
       resolver.traceTs &&
       (resolvedUrl.endsWith('.ts') || resolvedUrl.endsWith('.tsx') || resolvedUrl.endsWith('.jsx'))

--- a/generator/test/resolve/wildcard-subpaths-conditions.test.js
+++ b/generator/test/resolve/wildcard-subpaths-conditions.test.js
@@ -1,0 +1,60 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+// A wildcard export behind a condition object must enumerate the subpaths that
+// actually resolve for the environment. Previously an unknown condition ordered
+// before "default" (here "types") shadowed it during enumeration, producing
+// ./src/a.d.ts subpaths that then failed to trace.
+// https://github.com/jspm/jspm/issues/2717
+
+const isBrowser = typeof process === 'undefined' || !process.versions?.node;
+
+if (!isBrowser) {
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    combineSubpaths: false
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-subpaths-conditions', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  assert.ok(
+    json.imports['wildcard-conditions-test/src/'],
+    'Should have trailing-slash entry for src/'
+  );
+  assert.ok(
+    json.imports['wildcard-conditions-test/dist/'],
+    'Should have trailing-slash entry for dist/'
+  );
+  assert.ok(
+    json.imports['wildcard-conditions-test/src/'].endsWith('/src/'),
+    'src/ should map to the "default" target, not the "types" target'
+  );
+}
+
+// Declaration files under a wildcard export are validly exported and must stay
+// resolvable, but must not be traced — their specifiers follow TypeScript
+// declaration resolution ("./x.js" naming an ./x.d.ts) rather than a runtime
+// module graph, so tracing them fails to resolve.
+if (!isBrowser) {
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules'
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-subpaths-conditions', import.meta.url).href,
+    subpaths: true
+  });
+
+  const resolved = generator.importMap.resolve(
+    'wildcard-conditions-test/src/decl.d.ts',
+    import.meta.url
+  );
+  assert.ok(resolved.endsWith('/src/decl.d.ts'), 'Declaration subpath should stay resolvable');
+}

--- a/generator/test/resolve/wildcard-subpaths-conditions.test.js
+++ b/generator/test/resolve/wildcard-subpaths-conditions.test.js
@@ -28,8 +28,8 @@ if (!isBrowser) {
     'Should have trailing-slash entry for src/'
   );
   assert.ok(
-    json.imports['wildcard-conditions-test/dist/'],
-    'Should have trailing-slash entry for dist/'
+    json.imports['wildcard-conditions-test/bundled/'],
+    'Should have trailing-slash entry for bundled/'
   );
   assert.ok(
     json.imports['wildcard-conditions-test/src/'].endsWith('/src/'),

--- a/generator/test/resolve/wildcard-subpaths-conditions/bundled/c.js
+++ b/generator/test/resolve/wildcard-subpaths-conditions/bundled/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/generator/test/resolve/wildcard-subpaths-conditions/index.js
+++ b/generator/test/resolve/wildcard-subpaths-conditions/index.js
@@ -1,0 +1,1 @@
+export const main = 'main';

--- a/generator/test/resolve/wildcard-subpaths-conditions/package.json
+++ b/generator/test/resolve/wildcard-subpaths-conditions/package.json
@@ -9,6 +9,6 @@
         "default": "./src/*"
       }
     },
-    "./dist/*": "./dist/*"
+    "./bundled/*": "./bundled/*"
   }
 }

--- a/generator/test/resolve/wildcard-subpaths-conditions/package.json
+++ b/generator/test/resolve/wildcard-subpaths-conditions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wildcard-conditions-test",
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./src/*": {
+      "import": {
+        "types": "./types/src/*",
+        "default": "./src/*"
+      }
+    },
+    "./dist/*": "./dist/*"
+  }
+}

--- a/generator/test/resolve/wildcard-subpaths-conditions/src/a.js
+++ b/generator/test/resolve/wildcard-subpaths-conditions/src/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/generator/test/resolve/wildcard-subpaths-conditions/src/b.js
+++ b/generator/test/resolve/wildcard-subpaths-conditions/src/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/generator/test/resolve/wildcard-subpaths-conditions/src/decl-dep.d.ts
+++ b/generator/test/resolve/wildcard-subpaths-conditions/src/decl-dep.d.ts
@@ -1,0 +1,1 @@
+export declare const dep: string;

--- a/generator/test/resolve/wildcard-subpaths-conditions/src/decl.d.ts
+++ b/generator/test/resolve/wildcard-subpaths-conditions/src/decl.d.ts
@@ -1,0 +1,2 @@
+import { dep } from "./decl-dep.js";
+export declare const a: string;

--- a/generator/test/resolve/wildcard-subpaths-conditions/types/src/a.d.ts
+++ b/generator/test/resolve/wildcard-subpaths-conditions/types/src/a.d.ts
@@ -1,0 +1,1 @@
+export declare const a: string;

--- a/generator/test/resolve/wildcard-subpaths-conditions/types/src/b.d.ts
+++ b/generator/test/resolve/wildcard-subpaths-conditions/types/src/b.d.ts
@@ -1,0 +1,1 @@
+export declare const b: string;


### PR DESCRIPTION
This fixes `subpaths: true` enumerating export subpaths that don't actually resolve, resolves #2717.

Enumeration and resolution had drifted apart. `Resolver.resolvePackageTarget` follows strict Node conditional resolution — only `default` and conditions in `env`. But `expandTargetResolutions`, which enumerates subpaths, interleaved that strict matching with a speculative walk into *unknown* conditions. Under `firstOnly` the first unknown condition short-circuits, so anything ordered ahead of `default` shadows it:

```js
{ worker: './w.js', default: './d.js' }  // enumerated as w.js, resolved as d.js
{ default: './d.js', worker: './w.js' }  // enumerated as d.js
```

Purely key-order dependent, and not specific to `types` — `bun`, `deno`, `edge-light`, `workerd` and any custom condition shadow the same way. The generator then enumerates a subpath the resolver won't produce, and the trace fails.

The speculative walk exists so packages exporting solely under conditions we don't know about still resolve to something, so it stays — just as a fallback rather than inline:

```js
if (!expandTargetResolutions(exports, files, env, targetList, [], true, false))
  expandTargetResolutions(exports, files, env, targetList, [], true, true);
```

The second, independent half of #2717 is that `colorjs.io` ships declarations inside `src/`, so `"./src/*": "./src/*"` correctly enumerates `./src/color.d.ts` — Node really does resolve it. The bug is tracing it: declaration specifiers follow TypeScript declaration resolution (a `./x.js` specifier naming an `./x.d.ts`), not a runtime module graph, so `Module not found .../src/space-coord-accessors.js`.

* Thread a `speculate` flag through `expandTargetResolutions` so strict resolution completes before any speculation, in the generator and in the CLI's copy of the same logic
* Treat `.d.ts` / `.d.mts` / `.d.cts` as carrying no dependencies in `createAnalysis`, alongside the existing `.wasm` / `.json` / `.css` cases

Declarations stay enumerated and mapped — they are validly exported, and `import './foo.d.ts' with { type: 'text' }` must keep resolving. They are simply not traced.

`colorjs.io@0.6.1` with `subpaths: true`, the reproduction from #2717, now produces:

```json
{
  "colorjs.io": "./node_modules/colorjs.io/dist/color.js",
  "colorjs.io/fn": "./node_modules/colorjs.io/src/index-fn.js",
  "colorjs.io/spaces": "./node_modules/colorjs.io/src/spaces/index.js",
  "colorjs.io/src/": "./node_modules/colorjs.io/src/",
  "colorjs.io/dist/": "./node_modules/colorjs.io/dist/"
}
```

This also resolves nudeps/nudeps#126, where the missing `src/` prefix left nothing for `condenseImports` to collapse and required a downstream `.d.ts` filter.

Test coverage is five unit cases in `package.test.ts` for condition ordering, the `types` wildcard case and wildcard-prefix derivation, plus a `wildcard-subpaths-conditions` fixture mirroring colorjs.io's shape — including a declaration importing a `.js` specifier that only exists as `.d.ts`. Both fail before the change.

Note this supersedes #2725, which skipped the `types` condition specifically. That does fix the shadowing for `types`, but leaves it for every other unknown condition, and does not fix #2717's own reproduction: colorjs.io reaches its `.d.ts` files through the `default` branch, not through `types`.
