### PR TITLE
fix: preserve input map subpath pins

### DIFF
--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -658,11 +658,15 @@ export interface ModuleAnalysis {
   cjsLazyDeps: string[] | null;
 }
 
+type InstallSubpath = '.' | `./${string}`;
+
+const rootInstallSubpath: InstallSubpath = '.';
+
 export interface Install {
   target: string | InstallTarget;
   alias?: string;
-  subpath?: '.' | `./${string}`;
-  subpaths?: ('.' | `./${string}`)[] | true;
+  subpath?: InstallSubpath;
+  subpaths?: InstallSubpath[] | true;
 }
 
 /**
@@ -1290,6 +1294,7 @@ export class Generator {
       mode ??= 'default';
 
       if (Object.keys(this.traceMap.installer!.installs.primary).length) {
+        const pins = this.traceMap.pins || Object.keys(this.traceMap.inputMap.imports);
         return this._install(
           Object.entries(this.traceMap.installer!.installs.primary).map(([alias, target]) => {
             const pkgTarget = this.traceMap.installer!.constraints.primary[alias];
@@ -1305,10 +1310,12 @@ export class Generator {
                 newTarget = `${pkgTarget.registry}:${pkgTarget.name}`;
               }
             }
+            const subpaths = getInstallReplaySubpaths(alias, pins);
 
             return {
               alias,
-              target: newTarget
+              target: newTarget,
+              subpaths
             } as Install;
           }),
           mode
@@ -2323,6 +2330,27 @@ async function installToTarget(
     alias: install.alias || alias,
     subpath: install.subpath || subpath
   };
+}
+
+function getInstallReplaySubpaths(alias: string, pins: string[]): InstallSubpath[] {
+  const subpaths = pins
+    .filter(pin => {
+      const isExactPin = pin === alias;
+      const isSubpathPin = pin.startsWith(alias) && pin[alias.length] === '/';
+      return isExactPin || isSubpathPin;
+    })
+    .map(pin => {
+      const pinSubpath = pin.slice(alias.length);
+      return toInstallSubpath(pinSubpath);
+    });
+
+  if (subpaths.length) return subpaths;
+  return [rootInstallSubpath];
+}
+
+function toInstallSubpath(pinSubpath: string): InstallSubpath {
+  if (!pinSubpath) return rootInstallSubpath;
+  return `.${pinSubpath}` as InstallSubpath;
 }
 
 function detectDefaultProvider(

--- a/generator/test/api/inputmap.test.js
+++ b/generator/test/api/inputmap.test.js
@@ -1,9 +1,26 @@
 import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
-// Skypack CDN does not support CORS, so skip in browser
+// These CDN URLs do not all support browser test CORS.
 const isBrowser = typeof process === 'undefined' || !process.versions?.node;
 if (!isBrowser) {
+const bootstrapIconsUrl =
+  'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css';
+
+const bootstrapIconsGenerator = new Generator({
+  inputMap: {
+    imports: {
+      'bootstrap-icons/font/bootstrap-icons.min.css': bootstrapIconsUrl
+    }
+  },
+  cache: false
+});
+
+await bootstrapIconsGenerator.install();
+assert.strictEqual(
+  bootstrapIconsGenerator.getMap().imports['bootstrap-icons/font/bootstrap-icons.min.css'],
+  bootstrapIconsUrl
+);
 
 const generator = new Generator({
   mapUrl: import.meta.url,
@@ -31,5 +48,4 @@ assert.deepEqual(json, {
     }
   }
 });
-
 }


### PR DESCRIPTION
Refs #2601

## Summary

This preserves input-map subpath pins when `Generator.install()` is called without arguments.

For an input map entry like:

```js
"bootstrap-icons/font/bootstrap-icons.min.css": "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
```

the argumentless install replay path was replaying the primary package lock as bootstrap-icons, which retraced the package root and failed for packages without a root export. This change replays the pinned subpath instead.

## Validation

```sh
node --test -C source --enable-source-maps generator/test/api/inputmap.test.js
node --test -C source --enable-source-maps generator/test/api/link.test.js generator/test/api/providerswitch.test.js generator/test/api/update.test.js
git diff --check
```

Manual repro:

```sh
node --input-type=module -C source --enable-source-maps <<'JS'
import { Generator } from '@jspm/generator'

const url = 'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css'

const generator = new Generator({
  inputMap: {
    imports: {
      'bootstrap-icons/font/bootstrap-icons.min.css': url
    }
  },
  cache: false
})

await generator.install()
console.log(JSON.stringify(generator.getMap(), null, 2))
JS
```

Output on this branch:

```jsonc
  {
    "imports": {
      "bootstrap-icons/font/bootstrap-icons.min.css":
      "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
    }
  }
```
