### PR TITLE
chore(generator): update to es-module-lexer v3 full build

### DIFF
--- a/generator/package.json
+++ b/generator/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@jspm/fetch": "^0.1.0",
     "@jspm/import-map": "^1.5.0",
-    "es-module-lexer": "^3.0.0",
+    "es-module-lexer": "^3.0.1",
     "minimatch": "^10.0.1",
     "pako": "^2.1.0",
     "sver": "^2.0.1",

--- a/generator/package.json
+++ b/generator/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@jspm/fetch": "^0.1.0",
     "@jspm/import-map": "^1.5.0",
-    "es-module-lexer": "^2.1.0",
+    "es-module-lexer": "^3.0.0",
     "minimatch": "^10.0.1",
     "pako": "^2.1.0",
     "sver": "^2.0.1",

--- a/generator/src/common/wrapper.ts
+++ b/generator/src/common/wrapper.ts
@@ -5,10 +5,10 @@ export async function getMaybeWrapperUrl(moduleUrl: any, fetchOpts: any) {
   await init;
   const source = await (await fetch(moduleUrl, fetchOpts)).text();
   const [imports, , facade] = parse(source);
-  const first = imports[0];
-  if (facade && first && first.type !== 'import-meta' && first.specifier) {
+  const specifier = imports[0]?.specifier;
+  if (facade && specifier) {
     try {
-      return new URL(first.specifier, moduleUrl).href;
+      return new URL(specifier, moduleUrl).href;
     } catch {}
   }
   return moduleUrl;

--- a/generator/src/common/wrapper.ts
+++ b/generator/src/common/wrapper.ts
@@ -5,9 +5,10 @@ export async function getMaybeWrapperUrl(moduleUrl: any, fetchOpts: any) {
   await init;
   const source = await (await fetch(moduleUrl, fetchOpts)).text();
   const [imports, , facade] = parse(source);
-  if (facade && imports.length) {
+  const first = imports[0];
+  if (facade && first && first.type !== 'import-meta' && first.specifier) {
     try {
-      return new URL(imports[0].n!, moduleUrl).href;
+      return new URL(first.specifier, moduleUrl).href;
     } catch {}
   }
   return moduleUrl;

--- a/generator/src/html/analyze.ts
+++ b/generator/src/html/analyze.ts
@@ -63,7 +63,7 @@ function collectImports(imports: ReadonlyArray<Import>, analysis: HtmlAnalysis) 
     if (impt.type === 'dynamic') {
       const specifier = dynamicImportSpecifier(impt);
       if (specifier) analysis.dynamicImports.add(specifier);
-    } else if (impt.type !== 'import-meta' && !impt.typeOnly) {
+    } else if (impt.specifier && !impt.typeOnly) {
       analysis.staticImports.add(impt.specifier);
     }
   }

--- a/generator/src/html/analyze.ts
+++ b/generator/src/html/analyze.ts
@@ -4,6 +4,8 @@ import { baseUrl, isPlain } from '../common/url.js';
 import { isWs, ParsedAttribute, ParsedTag, parseHtml } from './lexer.js';
 // @ts-ignore
 import { parse } from 'es-module-lexer/js';
+import type { Import } from 'es-module-lexer';
+import { dynamicImportSpecifier } from '../trace/analysis.js';
 
 export interface HtmlAttr {
   quote: '"' | "'" | '';
@@ -54,6 +56,17 @@ function toHtmlAttrs(source: string, attributes: ParsedAttribute[]): Record<stri
   return Object.fromEntries(
     attributes.map(attr => readAttr(source, attr)).map(attr => [attr.name, attr])
   );
+}
+
+function collectImports(imports: ReadonlyArray<Import>, analysis: HtmlAnalysis) {
+  for (const impt of imports) {
+    if (impt.type === 'dynamic') {
+      const specifier = dynamicImportSpecifier(impt);
+      if (specifier) analysis.dynamicImports.add(specifier);
+    } else if (impt.type !== 'import-meta' && !impt.typeOnly) {
+      analysis.staticImports.add(impt.specifier);
+    }
+  }
 }
 
 export function analyzeHtml(source: string, url: URL = baseUrl): HtmlAnalysis {
@@ -127,10 +140,7 @@ export function analyzeHtml(source: string, url: URL = baseUrl): HtmlAnalysis {
             }
           } else {
             const [imports, , facade] = parse(source.slice(tag.innerStart, tag.innerEnd)) || [];
-            for (const { n, d } of imports) {
-              if (!n) continue;
-              (d === -1 ? analysis.staticImports : analysis.dynamicImports).add(n);
-            }
+            collectImports(imports, analysis);
             if (!facade) {
               analysis.inlineModules.push({
                 start: tag.start,
@@ -157,10 +167,7 @@ export function analyzeHtml(source: string, url: URL = baseUrl): HtmlAnalysis {
             }
           } else {
             const [imports] = parse(source.slice(tag.innerStart, tag.innerEnd)) || [];
-            for (const { n, d } of imports) {
-              if (!n) continue;
-              (d === -1 ? analysis.staticImports : analysis.dynamicImports).add(n);
-            }
+            collectImports(imports, analysis);
           }
         }
 

--- a/generator/src/trace/analysis.ts
+++ b/generator/src/trace/analysis.ts
@@ -1,5 +1,6 @@
 import { JspmError } from '../common/err.js';
 import { getIntegrity } from '../common/integrity.js';
+import type { Import } from 'es-module-lexer';
 
 export type Analysis =
   | AnalysisData
@@ -22,8 +23,14 @@ export interface AnalysisData {
 export { createTsAnalysis } from './ts.js';
 export { createCjsAnalysis } from './cjs.js';
 
+// Template literal dynamic imports are reported as globs, which cannot be traced
+export function dynamicImportSpecifier(impt: Import): string | undefined {
+  if (impt.type !== 'dynamic' || !impt.specifier || impt.specifier.includes('*')) return undefined;
+  return impt.specifier;
+}
+
 export async function createEsmAnalysis(
-  imports: any[],
+  imports: ReadonlyArray<Import>,
   source: string,
   url: string
 ): Promise<Analysis> {
@@ -32,24 +39,12 @@ export async function createEsmAnalysis(
   const deps: string[] = [];
   const dynamicDeps: string[] = [];
   for (const impt of imports) {
-    if (impt.d === -1) {
-      if (!deps.includes(impt.n)) deps.push(impt.n);
-      continue;
-    }
-    // dynamic import -> deoptimize trace all dependencies (and all their exports)
-    if (impt.d >= 0) {
-      if (impt.n) {
-        try {
-          dynamicDeps.push(impt.n);
-        } catch (e) {
-          console.warn(
-            `TODO: Dynamic import custom expression tracing in ${url} for:\n\n${source.slice(
-              impt.ss,
-              impt.se
-            )}\n`
-          );
-        }
-      }
+    if (impt.type === 'dynamic') {
+      // dynamic import -> deoptimize trace all dependencies (and all their exports)
+      const specifier = dynamicImportSpecifier(impt);
+      if (specifier) dynamicDeps.push(specifier);
+    } else if (impt.type !== 'import-meta' && !impt.typeOnly) {
+      if (!deps.includes(impt.specifier)) deps.push(impt.specifier);
     }
   }
   const size = source.length;
@@ -74,7 +69,7 @@ function systemMatch(code: string) {
 
 export async function createSystemAnalysis(
   source: string,
-  imports: string[],
+  imports: ReadonlyArray<Import>,
   url: string
 ): Promise<Analysis> {
   const [, rawDeps, contextId] = systemMatch(source) || [];

--- a/generator/src/trace/analysis.ts
+++ b/generator/src/trace/analysis.ts
@@ -43,7 +43,7 @@ export async function createEsmAnalysis(
       // dynamic import -> deoptimize trace all dependencies (and all their exports)
       const specifier = dynamicImportSpecifier(impt);
       if (specifier) dynamicDeps.push(specifier);
-    } else if (impt.type !== 'import-meta' && !impt.typeOnly) {
+    } else if (impt.specifier && !impt.typeOnly) {
       if (!deps.includes(impt.specifier)) deps.push(impt.specifier);
     }
   }

--- a/generator/src/trace/cjs.ts
+++ b/generator/src/trace/cjs.ts
@@ -1,5 +1,6 @@
 import { getIntegrity } from '../common/integrity.js';
-import { Analysis } from './analysis.js';
+import { Analysis, dynamicImportSpecifier } from './analysis.js';
+import type { Import } from 'es-module-lexer';
 
 // See: https://nodejs.org/docs/latest/api/modules.html#the-module-scope
 const cjsGlobals: string[] = ['__dirname', '__filename', 'exports', 'module', 'require'];
@@ -11,7 +12,7 @@ export function setBabel(_babel: any) {
 }
 
 export async function createCjsAnalysis(
-  imports: any,
+  imports: ReadonlyArray<Import>,
   source: string,
   url: string
 ): Promise<Analysis> {
@@ -96,7 +97,7 @@ export async function createCjsAnalysis(
 
   return {
     deps: [...requires],
-    dynamicDeps: imports.filter((impt: any) => impt.n).map((impt: any) => impt.n),
+    dynamicDeps: imports.map(dynamicImportSpecifier).filter(s => s !== undefined),
     cjsLazyDeps: [...lazy],
     size: source.length,
     format: 'commonjs',
@@ -105,7 +106,12 @@ export async function createCjsAnalysis(
   };
 }
 
-function buildDynamicString(node: any, fileName: any, isEsm = false, lastIsWildcard = false): string {
+function buildDynamicString(
+  node: any,
+  fileName: any,
+  isEsm = false,
+  lastIsWildcard = false
+): string {
   if (node.type === 'StringLiteral') {
     return node.value;
   }

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -23,9 +23,8 @@ import { isNode } from '../common/env.js';
 let realpath: any, pathToFileURL: any;
 
 export function setPathFns(_realpath: any, _pathToFileURL: any) {
-  (realpath = _realpath), (pathToFileURL = _pathToFileURL);
+  ((realpath = _realpath), (pathToFileURL = _pathToFileURL));
 }
-
 
 function isResponseImmutable(headers: any): boolean {
   if (!headers?.get) return false;
@@ -1063,8 +1062,12 @@ async function getAnalysis(resolver: Resolver, resolvedUrl: string): Promise<Ana
       } catch {}
     }
 
-    const [imports, exports] = parse(sourceText) as any as [any[], string[]];
-    if (imports.every(impt => impt.d > 0) && !exports.length && resolvedUrl.startsWith('file:')) {
+    const [imports, exports] = parse(sourceText);
+    if (
+      imports.every(impt => impt.type === 'dynamic') &&
+      !exports.length &&
+      resolvedUrl.startsWith('file:')
+    ) {
       // Support CommonJS package boundary checks for non-ESM on file: protocol only
       if (parentIsRequire) {
         if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "@babel/preset-typescript": "^7.24.7",
         "@jspm/fetch": "^0.1.0",
         "@jspm/import-map": "^1.5.0",
-        "es-module-lexer": "^2.1.0",
+        "es-module-lexer": "^3.0.0",
         "minimatch": "^10.0.1",
         "pako": "^2.1.0",
         "sver": "^2.0.1",
@@ -5008,9 +5008,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-3.0.0.tgz",
+      "integrity": "sha512-lvKy17U7Ppc8aZrar+NhN7UnyyQUnNeNlxYPLBIuYYu1jTaQOLqHSAwTbQNaw+dV0dNa+GRH8WNN0txo5d8pXw==",
       "license": "MIT"
     },
     "node_modules/esbuild": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "@babel/preset-typescript": "^7.24.7",
         "@jspm/fetch": "^0.1.0",
         "@jspm/import-map": "^1.5.0",
-        "es-module-lexer": "^3.0.0",
+        "es-module-lexer": "^3.0.1",
         "minimatch": "^10.0.1",
         "pako": "^2.1.0",
         "sver": "^2.0.1",
@@ -5008,9 +5008,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-3.0.0.tgz",
-      "integrity": "sha512-lvKy17U7Ppc8aZrar+NhN7UnyyQUnNeNlxYPLBIuYYu1jTaQOLqHSAwTbQNaw+dV0dNa+GRH8WNN0txo5d8pXw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-3.0.1.tgz",
+      "integrity": "sha512-cTSiWRQKZKC3pcN/DoVUTxoTlTJcj0bs89JAJQW/pmHWRve/O67cKe1rBkjDCDL2wat927qH55aEWoNVS0RqGg==",
       "license": "MIT"
     },
     "node_modules/esbuild": {


### PR DESCRIPTION
This updates the generator to the es-module-lexer v3 full build (3.0.1).

The v3 full build replaces the terse `{ n, d, ss, se }` record shape with a `type`-discriminated union (`static` / `dynamic` / `import-meta` / `reexport-star`), so every consumer of the lexer output is migrated to the new field names:

* `es-module-lexer` and `es-module-lexer/js` remain the entry points used, both now being full builds
* Template-literal dynamic imports are reported by v3 as `*` globs rather than `undefined`, so a `dynamicImportSpecifier` helper filters these out of dynamic dependency tracing as before
* TypeScript type-only imports lexed by the full build are skipped in dependency analysis
* Lexer results are typed via the `Import` type instead of `any`

```ts
if (impt.d === -1) deps.push(impt.n);
```

```ts
if (impt.specifier && !impt.typeOnly) deps.push(impt.specifier);
```

Since 3.0.1 `import.meta` records carry `specifier: null`, dependency loops filter on `specifier` directly without narrowing on `type`.

Parse error message format is unchanged in v3 so the existing parse error reporting in the resolver applies as-is. Covered by the existing generator trace and HTML analysis test suites.